### PR TITLE
fix: refactor and update mailgun service to allow different attachment

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,6 +1,6 @@
 # Server
 SERVER_PORT=
-
+REQUEST_MAX_SIZE= # Max Size of Request, Default is 50mb
 # Node env
 NODE_ENV= # Use "development" for graphql playground to work
 

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -31,6 +31,7 @@
         "graphql": "^16.8.1",
         "graphql-type-json": "^0.3.2",
         "mailgun.js": "^10.2.1",
+        "mime-types": "^2.1.35",
         "mysql2": "^3.10.0",
         "nest-winston": "^1.10.0",
         "nodemailer": "^6.9.13",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -50,6 +50,7 @@
     "graphql": "^16.8.1",
     "graphql-type-json": "^0.3.2",
     "mailgun.js": "^10.2.1",
+    "mime-types": "^2.1.35",
     "mysql2": "^3.10.0",
     "nest-winston": "^1.10.0",
     "nodemailer": "^6.9.13",

--- a/apps/api/src/database/migrations/1718945071282-UpdateDataColumnType.ts
+++ b/apps/api/src/database/migrations/1718945071282-UpdateDataColumnType.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateDataColumnType1718945071282 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Update the 'data' column type to LONGTEXT
+    await queryRunner.query(`
+            ALTER TABLE notify_notifications MODIFY COLUMN data LONGTEXT;
+        `);
+
+    // Update the 'result' column type to LONGTEXT
+    await queryRunner.query(`
+            ALTER TABLE notify_notifications MODIFY COLUMN result LONGTEXT;
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert the 'data' column type to its previous type (assuming TEXT)
+    await queryRunner.query(`
+            ALTER TABLE notify_notifications MODIFY COLUMN data TEXT;
+        `);
+
+    // Revert the 'result' column type to its previous type (assuming TEXT)
+    await queryRunner.query(`
+            ALTER TABLE notify_notifications MODIFY COLUMN result TEXT;
+        `);
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -9,6 +9,7 @@ import { HttpExceptionFilter } from './common/http-exception.filter';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import * as packageJson from '../package.json';
 import { useContainer } from 'class-validator';
+import { urlencoded, json } from 'express';
 
 const logDir = 'logs';
 
@@ -34,6 +35,8 @@ async function bootstrap(): Promise<void> {
   SwaggerModule.setup('api', app, document);
   app.useGlobalPipes(new ValidationPipe());
   app.useGlobalFilters(new HttpExceptionFilter(new JsendFormatter()));
+  app.use(json({ limit: configService.get('REQUEST_MAX_SIZE', '50mb') }));
+  app.use(urlencoded({ extended: true, limit: configService.get('REQUEST_MAX_SIZE', '50mb') }));
   // TODO: Update origin as needed
   app.enableCors({ origin: '*', credentials: true });
   await app.listen(configService.getOrThrow('SERVER_PORT'));

--- a/apps/api/src/modules/notifications/dtos/providers/mailgun-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/mailgun-data.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsOptional, ValidateIf } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, ValidateIf, ValidateNested } from 'class-validator';
 import {
   AttachmentValidation,
   CreateNotificationAttachmentDto,
@@ -31,6 +31,7 @@ export class MailgunDataDto {
   html: string;
 
   @IsOptional()
+  @ValidateNested({ each: true })
   @Type(() => CreateNotificationAttachmentDto)
   @AttachmentValidation()
   attachments: CreateNotificationAttachmentDto[];


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [ ] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [x] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

- Support of different attachments allowed in mailgun.
- We expect data of attachments as base64 String of the file Buffer.

**Related changes:**

- Update data column type as longtext.
- Add env value called `REQUEST_MAX_SIZE` which determines size of request to support multiple attachments. Default Value is `50mb`.

**Screenshots:**
![image](https://github.com/OsmosysSoftware/osmo-x/assets/14059393/867b9687-3079-456b-9d36-904d48487295)


**Query request and response:**

N/A

**Documentation changes:**
N/A

**Test suite output:**

N/A

**Pending actions:**

- Need to add a common file path solution to all providers to handle the issue.

**Additional notes:**

We probably don't need to support anything other than base64 string in request for mailgun atleast.
Need to find a common solution for other providers too wherein file attachments are direct file path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration variable `REQUEST_MAX_SIZE` to set the maximum request size (default: 50mb).
  - Added the `"mime-types"` package dependency for enhanced MIME type handling.

- **Bug Fixes**
  - Updated validation for nested objects in `MailgunDataDto` to improve attachment handling.

- **Improvements**
  - Enhanced `MailgunService` to handle file reading and content type lookup for attachments correctly.
  - Upgraded database column types in `notify_notifications` table to `LONGTEXT` for better data storage.

- **Chores**
  - Added middleware for parsing JSON and URL-encoded data in NestJS application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->