### PR TITLE
docs: update api usage guide to use x-api-key

### DIFF
--- a/apps/api/docs/usage-guide.md
+++ b/apps/api/docs/usage-guide.md
@@ -12,7 +12,7 @@ Welcome to the usage guide for OsmoX, a powerful notification management system 
   - [1. Overview](#1-overview)
   - [2. Pushing Data to the Database](#2-pushing-data-to-the-database)
   - [3. Using the OsmoX API](#3-using-the-osmox-api)
-    - [Authorization Header](#authorization-header)
+    - [x-api-key Header](#x-api-key-header)
   - [4. Tracking Notification Status](#4-tracking-notification-status)
   - [5. Available Channel Types](#5-available-channel-types)
   - [6. Delivery Status Information](#6-delivery-status-information)
@@ -32,12 +32,12 @@ To use the OsmoX API, follow these steps:
 - **Method:** POST
 - **Endpoint:** `/notifications`
 
-### Authorization Header
+### x-api-key Header
 
-To add a bearer token to the Authorization header, use the following format:
+To add the API key to the x-api-key header, use the following format:
 
 ```plaintext
-Authorization: Bearer SERVER_API_KEY_VALUE
+x-api-key: SERVER_API_KEY_VALUE
 ```
 
 Replace `SERVER_API_KEY_VALUE` with the actual API key value you want to include in the header.


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [ ] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [x] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

Update OsmoX API documentation to mention x-api-key instead of Authorization header.
As we now have x-api-key: SERVER_API_KEY_VALUE header instead of Authorization: Bearer SERVER_API_KEY_VALUE

**Related changes:**

NA

**Screenshots:**

NA

**Query request and response:**

NA

**Documentation changes:**

NA

**Test suite output:**

NA

**Pending actions:**

NA

**Additional notes:**

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API usage guide to use "x-api-key" header instead of "Authorization" header for adding the API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->