### PR TITLE
docs: remove channeltype from sample request queries

### DIFF
--- a/apps/api/docs/channels/wa-360Dialog.md
+++ b/apps/api/docs/channels/wa-360Dialog.md
@@ -36,7 +36,6 @@ Here's a sample request body:
 {
     // Set your respective providerId. ChannelType associated with providerId should be 3 (360Dialog)
     "providerId": 3,
-    "channelType": 3,
     "data": {
         "to": "919004812051",
         "type": "template",
@@ -104,4 +103,3 @@ Here's a sample request body:
 References
 - https://docs.360dialog.com/partner/first-steps/sandbox#example-request-payload
 - https://docs.360dialog.com/partner/first-steps/sandbox#5.-send-a-template-message-optional
-  

--- a/apps/api/docs/channels/wa-Twilio.md
+++ b/apps/api/docs/channels/wa-Twilio.md
@@ -51,4 +51,4 @@ Here's a sample request body:
 
 References
 
-- https://www.twilio.com/docs/whatsapp
+- [Twilio WhatsApp documentation](https://www.twilio.com/docs/whatsapp)

--- a/apps/api/docs/channels/wa-Twilio.md
+++ b/apps/api/docs/channels/wa-Twilio.md
@@ -36,7 +36,6 @@ Here's a sample request body:
 {
   // Set your respective providerId. ChannelType associated with providerId should be 4 (Twilio WhatsApp)
   "providerId": 4,
-  "channelType": 4,
   "data": {
       "to": "+919004812051",
       "message": "Your appointment is coming up on July 21 at 3PM"
@@ -53,4 +52,3 @@ Here's a sample request body:
 References
 
 - https://www.twilio.com/docs/whatsapp
-  


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [ ] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [x] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [x] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

This PR removes any mention of `channelType` in sample request queries for the different providers. This is no longer needed in favour of using `providerId`.

**Related changes:**

N/A

**Screenshots:**

N/A

**Query request and response:**

N/A

**Documentation changes:**

- Removed the channelType property in docs for wa-Twilio and wa-360Dialog

**Test suite output:**

N/A

**Pending actions:**

N/A

**Additional notes:**

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation for 360Dialog by removing the `channelType` field from the sample request body JSON.
  - Updated the documentation for Twilio WhatsApp integration by removing the `channelType` field from the sample request body JSON.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->