### PR TITLE
feat: add retry and delivery confirmation for wa twilio business

### DIFF
--- a/apps/api/src/common/constants/notifications.ts
+++ b/apps/api/src/common/constants/notifications.ts
@@ -28,6 +28,10 @@ export const ProviderDeliveryStatus = {
     SUCCESS_STATES: ['sent', 'delivered', 'read'],
     FAILURE_STATES: ['failed', 'undelivered'],
   },
+  WA_TWILIO_BUSINESS: {
+    SUCCESS_STATES: ['sent', 'delivered', 'read'],
+    FAILURE_STATES: ['failed', 'undelivered'],
+  },
 };
 
 export const SkipProviderConfirmationChannels = [];

--- a/apps/api/src/jobs/consumers/notifications/waTwilioBusiness-notifications.job.consumer.ts
+++ b/apps/api/src/jobs/consumers/notifications/waTwilioBusiness-notifications.job.consumer.ts
@@ -5,10 +5,12 @@ import { Notification } from 'src/modules/notifications/entities/notification.en
 import { NotificationConsumer } from './notification.consumer';
 import {
   WaTwilioBusinessData,
+  WaTwilioBusinessResponseData,
   WaTwilioBusinessService,
 } from 'src/modules/providers/wa-twilio-business/wa-twilio-business.service';
 import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { ProviderDeliveryStatus, DeliveryStatus } from 'src/common/constants/notifications';
 
 @Injectable()
 export class WaTwilioBusinessNotificationsConsumer extends NotificationConsumer {
@@ -30,6 +32,30 @@ export class WaTwilioBusinessNotificationsConsumer extends NotificationConsumer 
         notification.data as unknown as WaTwilioBusinessData,
         notification.providerId,
       );
+    });
+  }
+
+  async processWaTwilioBusinessNotificationConfirmationQueue(id: number): Promise<void> {
+    return super.processAwaitingConfirmationNotificationQueue(id, async () => {
+      const notification = (await this.notificationsService.getNotificationById(id))[0];
+      const result = await this.waTwilioBusinessService.getDeliveryStatus(
+        (notification.result.result as WaTwilioBusinessResponseData).sid as string,
+        notification.providerId,
+      );
+      const deliveryStatus = result.status;
+
+      if (ProviderDeliveryStatus.WA_TWILIO_BUSINESS.FAILURE_STATES.includes(deliveryStatus)) {
+        return { result, deliveryStatus: DeliveryStatus.PENDING };
+      }
+
+      if (ProviderDeliveryStatus.WA_TWILIO_BUSINESS.SUCCESS_STATES.includes(deliveryStatus)) {
+        return { result, deliveryStatus: DeliveryStatus.SUCCESS };
+      }
+
+      return {
+        result,
+        deliveryStatus: DeliveryStatus.AWAITING_CONFIRMATION,
+      };
     });
   }
 }

--- a/apps/api/src/modules/notifications/queues/queue.service.ts
+++ b/apps/api/src/modules/notifications/queues/queue.service.ts
@@ -107,8 +107,14 @@ export class QueueService {
         case `${QueueAction.SEND}-${ChannelType.SMS_PLIVO}`:
           await this.smsPlivoNotificationConsumer.processSmsPlivoNotificationQueue(job.data.id);
           break;
+        // WA_TWILIO_BUSINESS cases
         case `${QueueAction.SEND}-${ChannelType.WA_TWILIO_BUSINESS}`:
           await this.waTwilioBusinessNotificationConsumer.processWaTwilioBusinessNotificationQueue(
+            job.data.id,
+          );
+          break;
+        case `${QueueAction.DELIVERY_STATUS}-${ChannelType.WA_TWILIO_BUSINESS}`:
+          await this.waTwilioBusinessNotificationConsumer.processWaTwilioBusinessNotificationConfirmationQueue(
             job.data.id,
           );
           break;

--- a/apps/api/src/modules/providers/wa-twilio-business/wa-twilio-business.service.ts
+++ b/apps/api/src/modules/providers/wa-twilio-business/wa-twilio-business.service.ts
@@ -58,4 +58,14 @@ export class WaTwilioBusinessService {
     });
     return message;
   }
+
+  async getDeliveryStatus(sid: string, providerId: number): Promise<WaTwilioBusinessResponseData> {
+    try {
+      await this.assignTransport(providerId);
+      const message = await this.twilioClient.messages(sid).fetch();
+      return message;
+    } catch (error) {
+      throw new Error(`Failed to fetch delivery status: ${error.message}`);
+    }
+  }
 }


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [ ] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [x] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

This PR adds the retry and provider delivery confirmation for Twilio WhatsApp Business channel type.

**Related changes:**

- Update ProviderDeliveryStatus to add WA_TWILIO_BUSINESS success and failure states
- Update waTwilioBusiness-notifications.job.consumer.ts to add a processWaTwilioBusinessNotificationConfirmationQueue() method for handling awaiting confirmation queue
- Update wa-twilio-business.service.ts to add a getDeliveryStatus() method for getting message status
- Update queue.service to add case for WA_TWILIO_BUSINESS delivery status queue and calling appropriate method

**Screenshots:**

N/A

**Query request and response:**

Logs for a sample request made:

```bash
[OsmoX] 21955  - 7/3/2024, 11:46:25 AM     LOG [NestApplication] Nest application successfully started +5ms
[OsmoX] 21955  - 7/3/2024, 11:46:26 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +359ms
[OsmoX] 21955  - 7/3/2024, 11:46:26 AM     LOG [NotificationsService] Getting all active pending notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:26 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +10ms
[OsmoX] 21955  - 7/3/2024, 11:46:26 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:26 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:26 AM     LOG [NotificationsService] Adding 0 awaiting confirmation notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:27 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +985ms
[OsmoX] 21955  - 7/3/2024, 11:46:27 AM     LOG [NotificationsService] Getting all active pending notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:27 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:27 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:27 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +3ms
[OsmoX] 21955  - 7/3/2024, 11:46:27 AM     LOG [NotificationsService] Adding 0 awaiting confirmation notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:28 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +991ms
[OsmoX] 21955  - 7/3/2024, 11:46:28 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:28 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:28 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:28 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:28 AM     LOG [NotificationsService] Adding 0 awaiting confirmation notifications to queue +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:29 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +998ms
[OsmoX] 21955  - 7/3/2024, 11:46:29 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:29 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:29 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:29 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:29 AM     LOG [NotificationsService] Adding 0 awaiting confirmation notifications to queue +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:29 AM     LOG [NotificationsService] Creating notification... +89ms
[OsmoX] 21955  - 7/3/2024, 11:46:29 AM     LOG  Notification created successfully. +9ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +898ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [NotificationsService] Adding 0 awaiting confirmation notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [NotificationsService] Adding 1 pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [QueueService] Creating new queue and worker for send-7-2 +1ms
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [NotificationsService] Getting notification with id: 64 +16ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [WaTwilioBusinessNotificationsConsumer] Sending notification with id: 64 +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:30 AM     LOG [NotificationsService] Getting notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:31 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +976ms
[OsmoX] 21955  - 7/3/2024, 11:46:31 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:31 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:31 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:31 AM     LOG [NotificationsService] Adding 0 awaiting confirmation notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:31 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:31 AM     LOG [QueueService] {"name":"64","data":{"id":64,"providerId":2},"opts":{"attempts":0,"delay":0},"id":"1","progress":0,"stacktrace":[],"attemptsStarted":1,"attemptsMade":1,"delay":0,"timestamp":1719987390015,"queueQualifiedName":"bull:send-7-2","processedOn":1719987390020,"token":"ca4ec78b-0311-479c-b027-f63c152fcafd:0","finishedOn":1719987391741} +739ms
[OsmoX] 21955  - 7/3/2024, 11:46:31 AM     LOG [QueueService] Job completed: 1 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +258ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [NotificationsService] Adding 1 awaiting confirmation notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [QueueService] Creating new queue and worker for delivery-status-7-2 +0ms
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
It is highly recommended to use a minimum Redis version of 6.2.0
             Current: 6.0.16
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [NotificationsService] Getting notification with id: 64 +6ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [WaTwilioBusinessNotificationsConsumer] Checking delivery status from provider for notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [NotificationsService] Getting notification with id: 64 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [QueueService] {"name":"64","data":{"id":64,"providerId":2},"opts":{"attempts":0,"delay":0},"id":"1","progress":0,"stacktrace":[],"attemptsStarted":1,"attemptsMade":1,"delay":0,"timestamp":1719987392008,"queueQualifiedName":"bull:delivery-status-7-2","processedOn":1719987392009,"token":"0a66737b-1db1-4257-a148-f29d9b6225b7:0","finishedOn":1719987392972} +962ms
[OsmoX] 21955  - 7/3/2024, 11:46:32 AM     LOG [QueueService] Job completed: 1 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +27ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [NotificationsService] Getting all active pending notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [NotificationsService] Adding 1 awaiting confirmation notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [NotificationsService] Getting notification with id: 64 +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [WaTwilioBusinessNotificationsConsumer] Checking delivery status from provider for notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:33 AM     LOG [NotificationsService] Getting notification with id: 64 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +994ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [NotificationsService] Adding 1 awaiting confirmation notifications to queue +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +3ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [QueueService] {"name":"64","data":{"id":64,"providerId":2},"opts":{"attempts":0,"delay":0},"id":"2","progress":0,"stacktrace":[],"attemptsStarted":1,"attemptsMade":1,"delay":0,"timestamp":1719987393004,"queueQualifiedName":"bull:delivery-status-7-2","processedOn":1719987393004,"token":"0a66737b-1db1-4257-a148-f29d9b6225b7:2","finishedOn":1719987394007} +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [QueueService] Job completed: 2 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [NotificationsService] Getting notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [WaTwilioBusinessNotificationsConsumer] Checking delivery status from provider for notification with id: 64 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:34 AM     LOG [NotificationsService] Getting notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +990ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [NotificationsService] Adding 1 awaiting confirmation notifications to queue +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [QueueService] {"name":"64","data":{"id":64,"providerId":2},"opts":{"attempts":0,"delay":0},"id":"3","progress":0,"stacktrace":[],"attemptsStarted":1,"attemptsMade":1,"delay":0,"timestamp":1719987394005,"queueQualifiedName":"bull:delivery-status-7-2","processedOn":1719987394007,"token":"0a66737b-1db1-4257-a148-f29d9b6225b7:2","finishedOn":1719987395011} +7ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [QueueService] Job completed: 3 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [NotificationsService] Getting notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [WaTwilioBusinessNotificationsConsumer] Checking delivery status from provider for notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:35 AM     LOG [NotificationsService] Getting notification with id: 64 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +988ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [NotificationsService] Adding 1 awaiting confirmation notifications to queue +4ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +3ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [QueueService] {"name":"64","data":{"id":64,"providerId":2},"opts":{"attempts":0,"delay":0},"id":"4","progress":0,"stacktrace":[],"attemptsStarted":1,"attemptsMade":1,"delay":0,"timestamp":1719987395007,"queueQualifiedName":"bull:delivery-status-7-2","processedOn":1719987395011,"token":"0a66737b-1db1-4257-a148-f29d9b6225b7:2","finishedOn":1719987396014} +4ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [QueueService] Job completed: 4 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [NotificationsService] Getting notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [WaTwilioBusinessNotificationsConsumer] Checking delivery status from provider for notification with id: 64 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:36 AM     LOG [NotificationsService] Getting notification with id: 64 +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:37 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +983ms
[OsmoX] 21955  - 7/3/2024, 11:46:37 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:37 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:37 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:37 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:37 AM     LOG [NotificationsService] Adding 0 awaiting confirmation notifications to queue +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:37 AM     LOG [QueueService] {"name":"64","data":{"id":64,"providerId":2},"opts":{"attempts":0,"delay":0},"id":"5","progress":0,"stacktrace":[],"attemptsStarted":1,"attemptsMade":1,"delay":0,"timestamp":1719987396013,"queueQualifiedName":"bull:delivery-status-7-2","processedOn":1719987396014,"token":"0a66737b-1db1-4257-a148-f29d9b6225b7:2","finishedOn":1719987397006} +4ms
[OsmoX] 21955  - 7/3/2024, 11:46:37 AM     LOG [QueueService] Job completed: 5 +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:38 AM     LOG [NotificationsService] Starting CRON job to add pending notifications to queue +994ms
[OsmoX] 21955  - 7/3/2024, 11:46:38 AM     LOG [NotificationsService] Getting all active pending notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:38 AM     LOG [NotificationsService] Starting CRON job to add notifications to queue for confirmation from provider +2ms
[OsmoX] 21955  - 7/3/2024, 11:46:38 AM     LOG [NotificationsService] Getting all awaiting confirmation notifications +0ms
[OsmoX] 21955  - 7/3/2024, 11:46:38 AM     LOG [NotificationsService] Adding 0 pending notifications to queue +1ms
[OsmoX] 21955  - 7/3/2024, 11:46:38 AM     LOG [NotificationsService] Adding 0 awaiting confirmation notifications to queue
```

**Documentation changes:**

N/A

**Test suite output:**

N/A

**Pending actions:**

N/A

**Additional notes:**

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Twilio business notifications support, including delivery status tracking for sent, delivered, read, failed, and undelivered messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->