### PR TITLE
feat: add retry for kaps system

### DIFF
--- a/apps/api/src/common/constants/notifications.ts
+++ b/apps/api/src/common/constants/notifications.ts
@@ -28,6 +28,10 @@ export const ProviderDeliveryStatus = {
     SUCCESS_STATES: ['sent', 'delivered', 'read'],
     FAILURE_STATES: ['failed', 'undelivered'],
   },
+  SMS_KAPSYSTEM: {
+    SUCCESS_STATES: ['DELIVRD'],
+    FAILURE_STATES: ['EXPIRED', 'UNDELIV', 'FAILED'],
+  },
 };
 
-export const SkipProviderConfirmationChannels = [];
+export const SkipProviderConfirmationChannels = [ChannelType.SMS_KAPSYSTEM];


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [ ] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [x] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

Add retry function for kaps provider 

**Related changes:**

update notification.ts file , added kaps configuration

**Screenshots:**

![image](https://github.com/OsmosysSoftware/osmo-x/assets/121787291/96d20e08-d06e-4c1f-963b-1a5a17239340)

In case of connection error Which is the first case it retry for 3 times then set the status as failed : delivery_status 6

If everything is fine it mark it as success : delivery_status 5

**Query request and response:**

N/A

**Documentation changes:**

N/A

**Test suite output:**

N/A

**Pending actions:**

N/A

**Additional notes:**

N/A
