### PR TITLE
feat: add retry and delivery confirmation for sms twilio

### DIFF
--- a/apps/api/src/common/constants/notifications.ts
+++ b/apps/api/src/common/constants/notifications.ts
@@ -28,6 +28,10 @@ export const ProviderDeliveryStatus = {
     SUCCESS_STATES: ['sent', 'delivered', 'read'],
     FAILURE_STATES: ['failed', 'undelivered'],
   },
+  SMS_TWILIO: {
+    SUCCESS_STATES: ['sent', 'delivered'],
+    FAILURE_STATES: ['failed', 'undelivered'],
+  },
 };
 
 export const SkipProviderConfirmationChannels = [];

--- a/apps/api/src/modules/notifications/queues/queue.service.ts
+++ b/apps/api/src/modules/notifications/queues/queue.service.ts
@@ -101,8 +101,14 @@ export class QueueService {
             job.data.id,
           );
           break;
+        // SMS_TWILIO cases
         case `${QueueAction.SEND}-${ChannelType.SMS_TWILIO}`:
           await this.smsTwilioNotificationConsumer.processSmsTwilioNotificationQueue(job.data.id);
+          break;
+        case `${QueueAction.DELIVERY_STATUS}-${ChannelType.SMS_TWILIO}`:
+          await this.smsTwilioNotificationConsumer.processSmsTwilioNotificationConfirmationQueue(
+            job.data.id,
+          );
           break;
         case `${QueueAction.SEND}-${ChannelType.SMS_PLIVO}`:
           await this.smsPlivoNotificationConsumer.processSmsPlivoNotificationQueue(job.data.id);

--- a/apps/api/src/modules/providers/sms-twilio/sms-twilio.service.ts
+++ b/apps/api/src/modules/providers/sms-twilio/sms-twilio.service.ts
@@ -55,4 +55,14 @@ export class SmsTwilioService {
     });
     return message;
   }
+
+  async getDeliveryStatus(sid: string, providerId: number): Promise<SmsTwilioResponseData> {
+    try {
+      await this.assignTransport(providerId);
+      const message = await this.twilioClient.messages(sid).fetch();
+      return message;
+    } catch (error) {
+      throw new Error(`Failed to fetch delivery status: ${error.message}`);
+    }
+  }
 }


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [ ] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

This PR adds the retry and provider delivery confirmation for Twilio SMS channel type.

**Related changes:**

- Update ProviderDeliveryStatus to add SMS_TWILIO success and failure states
- Update smsTwilio-notifications.job.consumer.ts to add a processSmsTwilioNotificationConfirmationQueue() method for handling awaiting confirmation queue
- Update sms-twilio.service.ts to add a getDeliveryStatus() method for getting message status
- Update queue.service to add case for SMS_TWILIO delivery status queue and calling appropriate method

**Screenshots:**

N/A

**Query request and response:**

N/A

**Documentation changes:**

N/A

**Test suite output:**

N/A

**Pending actions:**

N/A

**Additional notes:**

N/A
