### PR TITLE
feat: move scheduler logic to separate script

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,4 +26,4 @@ RUN npm run build
 EXPOSE 3000
 
 # Command to start your NestJS application
-CMD src/modules/notifications/schedule/scheduler.sh & node dist/src/main.js
+CMD ./scheduler.sh & node dist/src/main.js

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,4 +26,4 @@ RUN npm run build
 EXPOSE 3000
 
 # Command to start your NestJS application
-CMD ["node", "dist/src/main.js"]
+CMD src/modules/notifications/schedule/scheduler.sh & node dist/src/main.js

--- a/apps/api/scheduler.sh
+++ b/apps/api/scheduler.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )"
-ENV=$SCRIPT_PATH/../../../../.env
 SCHEDULE_TIME=5
 
-source "${SCRIPT_PATH}/../../../../.env"
+source ".env"
 
 BASE_URL="http://localhost:${SERVER_PORT}/notifications"
 

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -12,6 +12,16 @@ export class NotificationsController {
     private logger: Logger,
   ) {}
 
+  @Post('queue')
+  async addNotificationsToQueue(): Promise<void> {
+    this.notificationService.addNotificationsToQueue();
+  }
+
+  @Post('confirm')
+  async getProviderConfirmation(): Promise<void> {
+    this.notificationService.getProviderConfirmation();
+  }
+
   @Post()
   @UseGuards(ApiKeyGuard)
   async addNotification(

--- a/apps/api/src/modules/notifications/schedule/schedule.service.ts
+++ b/apps/api/src/modules/notifications/schedule/schedule.service.ts
@@ -1,17 +1,17 @@
 import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+// import { Cron, CronExpression } from '@nestjs/schedule';
 import { NotificationsService } from '../notifications.service';
 
 @Injectable()
 export class ScheduleService {
   constructor(private readonly notificationsService: NotificationsService) {}
 
-  @Cron(CronExpression.EVERY_SECOND)
+  // @Cron(CronExpression.EVERY_SECOND)
   async addNotificationsToQueue(): Promise<void> {
     this.notificationsService.addNotificationsToQueue();
   }
 
-  @Cron(CronExpression.EVERY_SECOND)
+  // @Cron(CronExpression.EVERY_SECOND)
   async getProviderConfirmation(): Promise<void> {
     this.notificationsService.getProviderConfirmation();
   }

--- a/apps/api/src/modules/notifications/schedule/scheduler.sh
+++ b/apps/api/src/modules/notifications/schedule/scheduler.sh
@@ -4,9 +4,7 @@ SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )"
 ENV=$SCRIPT_PATH/../../../../.env
 SCHEDULE_TIME=5
 
-if [ -f "$ENV" ]; then
-  export "$(grep '^SERVER_PORT=' "$ENV" | xargs)"
-fi
+source "${SCRIPT_PATH}/../../../../.env"
 
 BASE_URL="http://localhost:${SERVER_PORT}/notifications"
 

--- a/apps/api/src/modules/notifications/schedule/scheduler.sh
+++ b/apps/api/src/modules/notifications/schedule/scheduler.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" || exit ; pwd -P )"
+ENV=$SCRIPT_PATH/../../../../.env
+SCHEDULE_TIME=5
+
+if [ -f "$ENV" ]; then
+  export "$(grep '^SERVER_PORT=' "$ENV" | xargs)"
+fi
+
+BASE_URL="http://localhost:${SERVER_PORT}/notifications"
+
+add_notifications_to_queue() {
+  curl -X POST "${BASE_URL}/queue" -H "Content-Type: application/json" -d '{}'
+}
+
+get_provider_confirmation() {
+  curl -X POST "${BASE_URL}/confirm" -H "Content-Type: application/json" -d '{}'
+}
+
+while true; do
+  add_notifications_to_queue
+  get_provider_confirmation
+  sleep $SCHEDULE_TIME
+done


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [ ] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

This PR moves the cron schedule job from Nestjs to a separate script to avoid issues with the random stopping of cron jobs. 
The docker container has been built and tested to ensure script is executing inside container as well.

**Related changes:**

- Comment out the schedule.service cron jobs to handle them via separate script
- Update notifications controller to add a queue and confirm method for adding notifications to respective queues
- Add a shell script that calls the API endpoints added for queue and confirm jobs, running at scheduled intervals
- Update Dockerfile for executing scheduler script in background before starting node server for api

**Screenshots:**
N/A

**Query request and response:**
N/A

**Documentation changes:**
N/A

**Test suite output:**
N/A

**Pending actions:**
N/A

**Additional notes:**
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new notification scheduling script that automates the queuing and confirmation of notifications.
	- Added two new asynchronous endpoints for managing notifications: one for adding notifications to a queue and another for confirming provider actions.

- **Bug Fixes**
	- Disabled automatic scheduling of notification-related tasks for more controlled execution of these processes.

- **Chores**
	- Updated the application startup sequence to include the new notification scheduling component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->