### PR TITLE
fix: add await before any kind of async method call

### DIFF
--- a/apps/api/src/jobs/consumers/notifications/notification.consumer.ts
+++ b/apps/api/src/jobs/consumers/notifications/notification.consumer.ts
@@ -43,7 +43,7 @@ export abstract class NotificationConsumer {
           `Channel type: ${notification.channelType} is included in skip queue. Provider confirmation skipped for notification id ${notification.id}`,
         );
         notification.deliveryStatus = DeliveryStatus.SUCCESS;
-        this.webhookService.triggerWebhook(notification);
+        await this.webhookService.triggerWebhook(notification);
       } else {
         this.logger.debug(
           `Notification id ${notification.id} is awaiting confirmation from provider`,
@@ -115,7 +115,7 @@ export abstract class NotificationConsumer {
       }
 
       if (notification.deliveryStatus === DeliveryStatus.SUCCESS) {
-        this.webhookService.triggerWebhook(notification);
+        await this.webhookService.triggerWebhook(notification);
       }
     } catch (error) {
       if (notification.retryCount < this.maxRetryCount) {
@@ -126,7 +126,7 @@ export abstract class NotificationConsumer {
           `Notification with ID ${notification.id} has attempted max allowed retries (provider confirmation), setting delivery status to ${DeliveryStatus.FAILED}`,
         );
         notification.deliveryStatus = DeliveryStatus.FAILED;
-        this.webhookService.triggerWebhook(notification);
+        await this.webhookService.triggerWebhook(notification);
       }
 
       this.logger.error(


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [ ] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

Ensure that await is added before any kind of async method call in api

**Related changes:**

NA

**Screenshots:**

NA

**Query request and response:**

NA

**Documentation changes:**

NA

**Test suite output:**

NA

**Pending actions:**

NA

**Additional notes:**

Check the following MDN link for adding additional `await` keyword when we are directly returning a promise
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#improving_stack_trace

However there was no significant difference in error handling, same error message was given in original code and the code where we added await so did not add it

Apart from mailgun, smtp and sns, all other providers first await in a variable and then return the variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved notification delivery process by implementing asynchronous webhook triggering, enhancing reliability and robustness.

- **Bug Fixes**
	- Fixed issues related to handling the delivery status of notifications by ensuring webhook completion before proceeding with subsequent logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->