### PR TITLE
feat: add support for sns sms provider

### DIFF
--- a/apps/api/OsmoX.postman_collection.json
+++ b/apps/api/OsmoX.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "82b7edbd-b320-46a8-bdc2-5fcb85d3bc4c",
+		"_postman_id": "8e75fe81-d5b4-4fda-bb05-a1c9e9224fce",
 		"name": "OsmoX",
 		"description": "OsmoX API helps creating new notifications, fetching existing notifications as well as perform authorization related tasks.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -1274,7 +1274,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the Twilio SMS channel type."
+						"description": "Allows successfully creating new notification for the Plivo SMS channel type."
 					},
 					"response": []
 				},
@@ -1335,7 +1335,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the Twilio SMS channel type."
+						"description": "Allows successfully creating new notification for the Plivo SMS channel type."
 					},
 					"response": []
 				},
@@ -1390,7 +1390,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio SMS channel type when missing the `to` field."
+						"description": "Allows representing failure in creating new notification for the Plivo SMS channel type when missing the `to` field."
 					},
 					"response": []
 				},
@@ -1444,7 +1444,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio SMS channel type when passing invalid API key."
+						"description": "Allows representing failure in creating new notification for the Plivo SMS channel type when passing invalid API key."
 					},
 					"response": []
 				}
@@ -1516,7 +1516,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the Twilio WhatsApp channel type."
+						"description": "Allows successfully creating new notification for the Twilio WhatsApp (Business) channel type."
 					},
 					"response": []
 				},
@@ -1577,7 +1577,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the Twilio WhatsApp channel type."
+						"description": "Allows successfully creating new notification for the Twilio WhatsApp (Business) channel type."
 					},
 					"response": []
 				},
@@ -1630,7 +1630,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio WhatsApp channel type when missing the `to` field."
+						"description": "Allows representing failure in creating new notification for the Twilio WhatsApp (Business) channel type when missing the `to` field."
 					},
 					"response": []
 				},
@@ -1684,7 +1684,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio WhatsApp channel type when passing invalid API key."
+						"description": "Allows representing failure in creating new notification for the Twilio WhatsApp (Business) channel type when passing invalid API key."
 					},
 					"response": []
 				}
@@ -1756,7 +1756,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the Twilio SMS channel type."
+						"description": "Allows successfully creating new notification for the KAPS SMS channel type."
 					},
 					"response": []
 				},
@@ -1817,7 +1817,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the Twilio SMS channel type."
+						"description": "Allows successfully creating new notification for the KAPS SMS channel type."
 					},
 					"response": []
 				},
@@ -1870,7 +1870,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio SMS channel type when missing the `to` field."
+						"description": "Allows representing failure in creating new notification for the KAPS SMS channel type when missing the `to` field."
 					},
 					"response": []
 				},
@@ -1924,7 +1924,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio SMS channel type when passing invalid API key."
+						"description": "Allows representing failure in creating new notification for the KAPS SMS channel type when passing invalid API key."
 					},
 					"response": []
 				}
@@ -1995,12 +1995,13 @@
 							"path": [
 								"notifications"
 							]
-						}
+						},
+						"description": "Allows successfully creating new notification for the SES Push Notification channel type for Android."
 					},
 					"response": []
 				},
 				{
-					"name": "PushNotification_IOS",
+					"name": "PushNotification_iOS",
 					"event": [
 						{
 							"listen": "test",
@@ -2060,7 +2061,8 @@
 							"path": [
 								"notifications"
 							]
-						}
+						},
+						"description": "Allows successfully creating new notification for the SES Push Notification channel type for iOS."
 					},
 					"response": []
 				}
@@ -2132,7 +2134,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the Twilio WhatsApp channel type."
+						"description": "Allows successfully creating new notification for the Twilio Voice Call channel type."
 					},
 					"response": []
 				},
@@ -2193,7 +2195,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the Twilio WhatsApp channel type."
+						"description": "Allows successfully creating new notification for the Twilio Voice Call channel type."
 					},
 					"response": []
 				},
@@ -2246,7 +2248,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio WhatsApp channel type when missing the `to` field."
+						"description": "Allows representing failure in creating new notification for the Twilio Voice Call channel type when missing the `to` field."
 					},
 					"response": []
 				},
@@ -2299,7 +2301,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio WhatsApp channel type when missing the `to` field."
+						"description": "Allows representing failure in creating new notification for the Twilio Voice Call channel type when missing both `url` and `twiml` fields."
 					},
 					"response": []
 				},
@@ -2353,7 +2355,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the Twilio WhatsApp channel type when passing invalid API key."
+						"description": "Allows representing failure in creating new notification for the Twilio Voice Call channel type when passing invalid API key."
 					},
 					"response": []
 				}
@@ -2382,9 +2384,9 @@
 									"    var jsonData = pm.response.json();",
 									"    pm.expect(jsonData.data).to.have.property(\"notification\").to.be.an(\"object\");",
 									"});",
-									"pm.test(\"Response 'channelType' is 12\", function () {",
+									"pm.test(\"Response 'channelType' is 11\", function () {",
 									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.data.notification).to.have.property(\"channelType\", 12);",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"channelType\", 11);",
 									"});",
 									"pm.test(\"Response 'deliveryStatus' is 1\", function () {",
 									"    var jsonData = pm.response.json();",
@@ -2413,7 +2415,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    // Assuming providerId 12 also has channelType 12\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+							"raw": "{\n    // Assuming providerId 11 also has channelType 11\n    \"providerId\": 11,\n    \"data\": {\n        \"from\": \"fromtestmail@gmail.com\",\n        \"to\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyTo\": \"replytestmail@gmail.com\"\n    }\n}"
 						},
 						"url": {
 							"raw": "localhost:3000/notifications",
@@ -2425,12 +2427,12 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the SMTP channel type."
+						"description": "Allows successfully creating new notification for the AWS SES channel type."
 					},
 					"response": []
 				},
 				{
-					"name": "Send SMTP Notification - Missing To Field Copy",
+					"name": "Send AWS SES Notification - Missing To Field",
 					"event": [
 						{
 							"listen": "test",
@@ -2466,7 +2468,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+							"raw": "{\n    \"providerId\": 11,\n    \"data\": {\n        \"from\": \"fromtestmail@gmail.com\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyTo\": \"replytestmail@gmail.com\"\n    }\n}"
 						},
 						"url": {
 							"raw": "localhost:3000/notifications",
@@ -2478,12 +2480,12 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the SMTP channel type when missing the `to` field."
+						"description": "Allows representing failure in creating new notification for the AWS SES channel type when missing the `to` field."
 					},
 					"response": []
 				},
 				{
-					"name": "Send SMTP Notification - Mismatch in ChannelType Copy",
+					"name": "Send AWS SES Notification - Mismatch in ChannelType",
 					"event": [
 						{
 							"listen": "test",
@@ -2527,7 +2529,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    // Assuming providerId 111 does not have channelType 12\n    \"providerId\": 111,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+							"raw": "{\n    // Assuming providerId 111 does not have channelType 11\n    \"providerId\": 111,\n    \"data\": {\n        \"from\": \"fromtestmail@gmail.com\",\n        \"to\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyTo\": \"replytestmail@gmail.com\"\n    }\n}"
 						},
 						"url": {
 							"raw": "localhost:3000/notifications",
@@ -2539,12 +2541,12 @@
 								"notifications"
 							]
 						},
-						"description": "Allows successfully creating new notification for the SMTP channel type."
+						"description": "Allows successfully creating new notification for the AWS SES channel type."
 					},
 					"response": []
 				},
 				{
-					"name": "Send SMTP Notification - Invalid API Key Copy",
+					"name": "Send AWS SES Notification - Invalid API Key",
 					"event": [
 						{
 							"listen": "test",
@@ -2581,7 +2583,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+							"raw": "{\n    \"providerId\": 11,\n    \"data\": {\n        \"from\": \"fromtestmail@gmail.com\",\n        \"to\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyTo\": \"replytestmail@gmail.com\"\n    }\n}"
 						},
 						"url": {
 							"raw": "localhost:3000/notifications",
@@ -2593,247 +2595,7 @@
 								"notifications"
 							]
 						},
-						"description": "Allows representing failure in creating new notification for the SMTP channel type when passing invalid API key."
-					},
-					"response": []
-				}
-			],
-			"description": "Collection of requests pertaining to creating notifications for the AWS SES channel type."
-		},
-		{
-			"name": "SNS SMS Notification",
-			"item": [
-				{
-					"name": "Send SNS SMS Notification - Success",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Response is valid JSON\", function () {",
-									"    pm.response.to.be.json;",
-									"});",
-									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.have.property(\"status\", \"success\");",
-									"    pm.expect(jsonData).to.have.property(\"data\").to.be.an(\"object\");",
-									"});",
-									"pm.test(\"Response contains a valid 'notification' object\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.data).to.have.property(\"notification\").to.be.an(\"object\");",
-									"});",
-									"pm.test(\"Response 'channelType' is 12\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.data.notification).to.have.property(\"channelType\", 12);",
-									"});",
-									"pm.test(\"Response 'deliveryStatus' is 1\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.data.notification).to.have.property(\"deliveryStatus\", 1);",
-									"});",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "x-api-key",
-								"value": "{{x-api-key}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    // Assuming providerId 12 also has channelType 12\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
-						},
-						"url": {
-							"raw": "localhost:3000/notifications",
-							"host": [
-								"localhost"
-							],
-							"port": "3000",
-							"path": [
-								"notifications"
-							]
-						},
-						"description": "Allows successfully creating new notification for the SMTP channel type."
-					},
-					"response": []
-				},
-				{
-					"name": "Send SNS SMS Notification - Missing phoneNumber Field",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Response is valid JSON\", function () {",
-									"    pm.response.to.be.json;",
-									"});",
-									"pm.test(\"Response for Invalid Data (Missing 'to' Value)\", function () {",
-									"    pm.expect(pm.response.code).to.equal(400);",
-									"    pm.expect(pm.response.json().status).to.equal(\"fail\");",
-									"    pm.expect(pm.response.json().data[0]).to.equal(\"to should not be empty\");",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "x-api-key",
-								"value": "{{x-api-key}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
-						},
-						"url": {
-							"raw": "localhost:3000/notifications",
-							"host": [
-								"localhost"
-							],
-							"port": "3000",
-							"path": [
-								"notifications"
-							]
-						},
-						"description": "Allows representing failure in creating new notification for the SMTP channel type when missing the `to` field."
-					},
-					"response": []
-				},
-				{
-					"name": "Send SNS SMS Notification - Mismatch in ChannelType",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Response is valid JSON\", function () {",
-									"    pm.response.to.be.json;",
-									"});",
-									"pm.test(\"Response code is 400 Bad Request\", function () {",
-									"    pm.expect(pm.response.code).to.equal(400);",
-									"});",
-									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.have.property(\"status\", \"fail\");",
-									"    pm.expect(jsonData).to.have.property(\"data\");",
-									"});",
-									"pm.test(\"Response does not contain a valid 'notification' object\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.data).to.not.have.property(\"notification\").to.be.an(\"object\");",
-									"});",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "x-api-key",
-								"value": "{{x-api-key}}",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    // Assuming providerId 111 does not have channelType 12\n    \"providerId\": 111,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
-						},
-						"url": {
-							"raw": "localhost:3000/notifications",
-							"host": [
-								"localhost"
-							],
-							"port": "3000",
-							"path": [
-								"notifications"
-							]
-						},
-						"description": "Allows successfully creating new notification for the SMTP channel type."
-					},
-					"response": []
-				},
-				{
-					"name": "Send SNS SMS Notification - Invalid API Key",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Response is valid JSON\", function () {",
-									"    pm.response.to.be.json;",
-									"});",
-									"pm.test(\"Failed request with invalid x-api-key\", function () {",
-									"    pm.expect(pm.response.code).to.equal(401);",
-									"    pm.expect(pm.response.json().status).to.equal(\"fail\");",
-									"    pm.expect(pm.response.json().data).to.equal(\"Invalid x-api-key\");",
-									"});",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "x-api-key",
-								"value": "bad-api-key",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
-						},
-						"url": {
-							"raw": "localhost:3000/notifications",
-							"host": [
-								"localhost"
-							],
-							"port": "3000",
-							"path": [
-								"notifications"
-							]
-						},
-						"description": "Allows representing failure in creating new notification for the SMTP channel type when passing invalid API key."
+						"description": "Allows representing failure in creating new notification for the AWS SES channel type when passing invalid API key."
 					},
 					"response": []
 				}
@@ -3254,7 +3016,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows successfully fetching all applications based on the options passed."
 					},
 					"response": []
 				},
@@ -3316,7 +3079,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when fetching all applications when using a NON ADMIN user for triggering request."
 					},
 					"response": []
 				},
@@ -3373,7 +3137,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when fetching all applications when using invalid/bad request."
 					},
 					"response": []
 				}
@@ -3439,7 +3204,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows successfully creating an application based on the options passed."
 					},
 					"response": []
 				},
@@ -3501,7 +3267,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when creating an application when using a NON ADMIN user for triggering request."
 					},
 					"response": []
 				},
@@ -3558,7 +3325,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when creating an application when using invalid/bad request."
 					},
 					"response": []
 				}
@@ -3628,7 +3396,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows successfully fetching all providers based on the options passed."
 					},
 					"response": []
 				},
@@ -3690,7 +3459,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when fetching all providers when using a NON ADMIN user for triggering request."
 					},
 					"response": []
 				},
@@ -3747,12 +3517,13 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when fetching all providers when using invalid/bad request."
 					},
 					"response": []
 				}
 			],
-			"description": "Collection of requests pertaining to fetching all applications."
+			"description": "Collection of requests pertaining to fetching all providers."
 		},
 		{
 			"name": "New Provider",
@@ -3813,7 +3584,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows successfully creating a provider based on the options passed."
 					},
 					"response": []
 				},
@@ -3875,7 +3647,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when creating a provider when using an invalid applicationId for triggering request."
 					},
 					"response": []
 				},
@@ -3937,7 +3710,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when creating a provider when using a NON ADMIN user for triggering request."
 					},
 					"response": []
 				},
@@ -3994,7 +3768,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when creating a provider when using invalid/bad request."
 					},
 					"response": []
 				}
@@ -4065,7 +3840,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows successfully registering a webhook based on the options passed."
 					},
 					"response": []
 				},
@@ -4132,7 +3908,8 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when registering a webhook when using already existing provider for request."
 					},
 					"response": []
 				},
@@ -4199,18 +3976,253 @@
 							"path": [
 								"graphql"
 							]
-						}
+						},
+						"description": "Allows representing failure when registering a webhook when using unknown provider for request."
 					},
 					"response": []
 				}
 			],
 			"description": "Collection of requests pertaining to webhook registration."
-		}
-	],
-	"variable": [
+		},
 		{
-			"key": "x-api-key",
-			"value": "OsmoX-test-key"
+			"name": "SNS SMS Notification",
+			"item": [
+				{
+					"name": "Send SNS SMS Notification - Success",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"status\", \"success\");",
+									"    pm.expect(jsonData).to.have.property(\"data\").to.be.an(\"object\");",
+									"});",
+									"pm.test(\"Response contains a valid 'notification' object\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data).to.have.property(\"notification\").to.be.an(\"object\");",
+									"});",
+									"pm.test(\"Response 'channelType' is 12\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"channelType\", 12);",
+									"});",
+									"pm.test(\"Response 'deliveryStatus' is 1\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"deliveryStatus\", 1);",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"to\": \"+919234567890\",\n        \"message\": \"This is a test notification\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows successfully creating new notification for the SMTP channel type."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SNS SMS Notification - Missing to Field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response for Invalid Data (Missing 'to' Value)\", function () {",
+									"    pm.expect(pm.response.code).to.equal(400);",
+									"    pm.expect(pm.response.json().status).to.equal(\"fail\");",
+									"    pm.expect(pm.response.json().data[0]).to.equal(\"to should not be empty\");",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"message\": \"This is a test notification\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows representing failure in creating new notification for the SMTP channel type when missing the `to` field."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SNS SMS Notification - Mismatch in ChannelType",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response code is 400 Bad Request\", function () {",
+									"    pm.expect(pm.response.code).to.equal(400);",
+									"});",
+									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"status\", \"fail\");",
+									"    pm.expect(jsonData).to.have.property(\"data\");",
+									"});",
+									"pm.test(\"Response does not contain a valid 'notification' object\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data).to.not.have.property(\"notification\").to.be.an(\"object\");",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 121,\n    \"data\": {\n        \"to\": \"+919234567890\",\n        \"message\": \"This is a test notification\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows successfully creating new notification for the SMTP channel type."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SNS SMS Notification - Invalid API Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Failed request with invalid x-api-key\", function () {",
+									"    pm.expect(pm.response.code).to.equal(401);",
+									"    pm.expect(pm.response.json().status).to.equal(\"fail\");",
+									"    pm.expect(pm.response.json().data).to.equal(\"Invalid x-api-key\");",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "bad-api-key",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"to\": \"+919234567890\",\n        \"message\": \"This is a test notification\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows representing failure in creating new notification for the SMTP channel type when passing invalid API key."
+					},
+					"response": []
+				}
+			],
+			"description": "Collection of requests pertaining to creating notifications for the AWS SES channel type."
 		}
 	]
 }

--- a/apps/api/OsmoX.postman_collection.json
+++ b/apps/api/OsmoX.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "c2243c60-46c3-488b-a822-72f0ad11f2d8",
+		"_postman_id": "82b7edbd-b320-46a8-bdc2-5fcb85d3bc4c",
 		"name": "OsmoX",
 		"description": "OsmoX API helps creating new notifications, fetching existing notifications as well as perform authorization related tasks.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "27217372"
+		"_exporter_id": "20654268"
 	},
 	"item": [
 		{
@@ -2361,6 +2361,486 @@
 			"description": "Collection of requests pertaining to creating notifications for the Twilio Voice Call channel type using templates."
 		},
 		{
+			"name": "AWS SES Notification",
+			"item": [
+				{
+					"name": "Send AWS SES Notification - Success",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"status\", \"success\");",
+									"    pm.expect(jsonData).to.have.property(\"data\").to.be.an(\"object\");",
+									"});",
+									"pm.test(\"Response contains a valid 'notification' object\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data).to.have.property(\"notification\").to.be.an(\"object\");",
+									"});",
+									"pm.test(\"Response 'channelType' is 12\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"channelType\", 12);",
+									"});",
+									"pm.test(\"Response 'deliveryStatus' is 1\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"deliveryStatus\", 1);",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    // Assuming providerId 12 also has channelType 12\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows successfully creating new notification for the SMTP channel type."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SMTP Notification - Missing To Field Copy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response for Invalid Data (Missing 'to' Value)\", function () {",
+									"    pm.expect(pm.response.code).to.equal(400);",
+									"    pm.expect(pm.response.json().status).to.equal(\"fail\");",
+									"    pm.expect(pm.response.json().data[0]).to.equal(\"to should not be empty\");",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows representing failure in creating new notification for the SMTP channel type when missing the `to` field."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SMTP Notification - Mismatch in ChannelType Copy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response code is 400 Bad Request\", function () {",
+									"    pm.expect(pm.response.code).to.equal(400);",
+									"});",
+									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"status\", \"fail\");",
+									"    pm.expect(jsonData).to.have.property(\"data\");",
+									"});",
+									"pm.test(\"Response does not contain a valid 'notification' object\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data).to.not.have.property(\"notification\").to.be.an(\"object\");",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    // Assuming providerId 111 does not have channelType 12\n    \"providerId\": 111,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows successfully creating new notification for the SMTP channel type."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SMTP Notification - Invalid API Key Copy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Failed request with invalid x-api-key\", function () {",
+									"    pm.expect(pm.response.code).to.equal(401);",
+									"    pm.expect(pm.response.json().status).to.equal(\"fail\");",
+									"    pm.expect(pm.response.json().data).to.equal(\"Invalid x-api-key\");",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "bad-api-key",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows representing failure in creating new notification for the SMTP channel type when passing invalid API key."
+					},
+					"response": []
+				}
+			],
+			"description": "Collection of requests pertaining to creating notifications for the AWS SES channel type."
+		},
+		{
+			"name": "SNS SMS Notification",
+			"item": [
+				{
+					"name": "Send SNS SMS Notification - Success",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"status\", \"success\");",
+									"    pm.expect(jsonData).to.have.property(\"data\").to.be.an(\"object\");",
+									"});",
+									"pm.test(\"Response contains a valid 'notification' object\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data).to.have.property(\"notification\").to.be.an(\"object\");",
+									"});",
+									"pm.test(\"Response 'channelType' is 12\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"channelType\", 12);",
+									"});",
+									"pm.test(\"Response 'deliveryStatus' is 1\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data.notification).to.have.property(\"deliveryStatus\", 1);",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    // Assuming providerId 12 also has channelType 12\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows successfully creating new notification for the SMTP channel type."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SNS SMS Notification - Missing phoneNumber Field",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response for Invalid Data (Missing 'to' Value)\", function () {",
+									"    pm.expect(pm.response.code).to.equal(400);",
+									"    pm.expect(pm.response.json().status).to.equal(\"fail\");",
+									"    pm.expect(pm.response.json().data[0]).to.equal(\"to should not be empty\");",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows representing failure in creating new notification for the SMTP channel type when missing the `to` field."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SNS SMS Notification - Mismatch in ChannelType",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Response code is 400 Bad Request\", function () {",
+									"    pm.expect(pm.response.code).to.equal(400);",
+									"});",
+									"pm.test(\"Response has valid 'status' and 'data' properties\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property(\"status\", \"fail\");",
+									"    pm.expect(jsonData).to.have.property(\"data\");",
+									"});",
+									"pm.test(\"Response does not contain a valid 'notification' object\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.data).to.not.have.property(\"notification\").to.be.an(\"object\");",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "{{x-api-key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    // Assuming providerId 111 does not have channelType 12\n    \"providerId\": 111,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows successfully creating new notification for the SMTP channel type."
+					},
+					"response": []
+				},
+				{
+					"name": "Send SNS SMS Notification - Invalid API Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Response is valid JSON\", function () {",
+									"    pm.response.to.be.json;",
+									"});",
+									"pm.test(\"Failed request with invalid x-api-key\", function () {",
+									"    pm.expect(pm.response.code).to.equal(401);",
+									"    pm.expect(pm.response.json().status).to.equal(\"fail\");",
+									"    pm.expect(pm.response.json().data).to.equal(\"Invalid x-api-key\");",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "x-api-key",
+								"value": "bad-api-key",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"providerId\": 12,\n    \"data\": {\n        \"fromAddress\": \"fromtestmail@gmail.com\",\n        \"toAddresses\": \"totestmail@gmail.co\",\n        \"subject\": \"Test subject\",\n        \"text\": \"This is a test notification\",\n        \"html\": \"<b>This is a test notification</b>\",\n        \"replyToAddresses\": \"replytestmail@gmail.com\"\n    }\n}"
+						},
+						"url": {
+							"raw": "localhost:3000/notifications",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"notifications"
+							]
+						},
+						"description": "Allows representing failure in creating new notification for the SMTP channel type when passing invalid API key."
+					},
+					"response": []
+				}
+			],
+			"description": "Collection of requests pertaining to creating notifications for the AWS SES channel type."
+		},
+		{
 			"name": "Authentication",
 			"item": [
 				{
@@ -3725,6 +4205,12 @@
 				}
 			],
 			"description": "Collection of requests pertaining to webhook registration."
+		}
+	],
+	"variable": [
+		{
+			"key": "x-api-key",
+			"value": "OsmoX-test-key"
 		}
 	]
 }

--- a/apps/api/docs/channels/sms-sns.md
+++ b/apps/api/docs/channels/sms-sns.md
@@ -36,10 +36,10 @@ Here's a sample request body:
 
 ```jsonc
 {
-    "providerId": 11,
+    "providerId": 12,
     "data": {
 
-        "phoneNumber": "+1234567890",
+        "to": "+919234567890",
         "message": "This is a test notification",
     }
 }

--- a/apps/api/docs/channels/sms-sns.md
+++ b/apps/api/docs/channels/sms-sns.md
@@ -1,0 +1,59 @@
+# AWS SNS
+
+Amazon Simple Notification Service (SNS) is a fully managed messaging service that supports application-to-application (A2A) and application-to-person (A2P) communication. Using AWS SNS, you can send SMS messages globally.
+
+Refer to the SNS documentation to dive deeper into the features AWS SNS offers and understand how it all works.
+
+## Values to Update in Database
+
+When using AWS SNS to send SMS via their API/Client, you need to provide certain variables that hold the SNS configuration details. Here are the values you need to update in table `notify_providers`:
+
+Create a new entry in table `notify_providers` and set the fields - `name`, `application_id`, `user_id`
+
+- Set field `channel_type` = 11 (for AWS SNS)
+- Set field `is_enabled` = 1 (to enable the newly created provider)
+
+Then set the following configurations in the `configuration` field
+
+| Key                   | Description                 |
+| --------------------- | --------------------------- |
+| AWS_ACCESS_KEY_ID     | Access key for AWS instance |
+| AWS_SECRET_ACCESS_KEY | Secret access key for AWS   |
+| AWS_REGION            | Region of the AWS instance  |
+
+```jsonc
+// Sample json to set in configuration field
+{
+    "AWS_ACCESS_KEY_ID":"Aws-Access-key",
+    "AWS_SECRET_ACCESS_KEY":"Aws-Secret-Key",
+    "AWS_REGION":"aws-region"
+}
+```
+
+### Sample Request Body
+
+Here's a sample request body:
+
+```jsonc
+{
+    "providerId": 11,
+    "data": {
+
+        "phoneNumber": "+1234567890",
+        "message": "This is a test notification",
+    }
+}
+```
+
+For further payload information, check the following link:
+
+### Documentation links
+
+- [What is AWS SNS](https://docs.aws.amazon.com/sns/latest/dg/welcome.html)
+- [Official AWS documentation for SNS integration](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/sns-examples-sending-sms.html)
+
+### Dependencies
+
+| Package Name        | Version  | Description                                                               |
+| ------------------- | -------- | ------------------------------------------------------------------------- |
+| @aws-sdk/client-sns | ^3.621.0 | AWS SDK for JavaScript, used to interact with AWS services including SNS. |

--- a/apps/api/src/common/constants/notifications.ts
+++ b/apps/api/src/common/constants/notifications.ts
@@ -18,7 +18,7 @@ export const ChannelType = {
   SMS_KAPSYSTEM: 8,
   PUSH_SNS: 9,
   VC_TWILIO: 10,
-  SMS_SNS: 11,
+  SMS_SNS: 12,
 };
 
 export const QueueAction = {

--- a/apps/api/src/common/constants/notifications.ts
+++ b/apps/api/src/common/constants/notifications.ts
@@ -18,6 +18,7 @@ export const ChannelType = {
   SMS_KAPSYSTEM: 8,
   PUSH_SNS: 9,
   VC_TWILIO: 10,
+  SMS_SNS: 11,
 };
 
 export const QueueAction = {
@@ -65,4 +66,5 @@ export const SkipProviderConfirmationChannels = [
   ChannelType.WA_360_DAILOG,
   ChannelType.PUSH_SNS,
   ChannelType.SMTP,
+  ChannelType.SMS_SNS,
 ];

--- a/apps/api/src/common/decorators/is-data-valid.decorator.ts
+++ b/apps/api/src/common/decorators/is-data-valid.decorator.ts
@@ -22,6 +22,7 @@ import { ProvidersService } from 'src/modules/providers/providers.service';
 import { SmsKapsystemDataDto } from 'src/modules/notifications/dtos/providers/smsKapsystem-data.dto';
 import { PushSnsDataDto } from 'src/modules/notifications/dtos/providers/pushSns-data.dto';
 import { VcTwilioDataDto } from 'src/modules/notifications/dtos/providers/vcTwilio-data.dto';
+import { SmsSnsDataDto } from 'src/modules/notifications/dtos/providers/smsSns-data.dto';
 
 @ValidatorConstraint({ name: 'isDataValidConstraint', async: true })
 @Injectable()
@@ -124,6 +125,13 @@ export class IsDataValidConstraint implements ValidatorConstraintInterface {
         const vcTwilioData = new VcTwilioDataDto();
         Object.assign(vcTwilioData, value);
         await validateAndThrowError(vcTwilioData);
+        return true;
+      }
+
+      case ChannelType.SMS_SNS: {
+        const snsSmsData = new SmsSnsDataDto();
+        Object.assign(snsSmsData, value);
+        await validateAndThrowError(snsSmsData);
         return true;
       }
 

--- a/apps/api/src/database/migrations/1723113193873-migration.ts
+++ b/apps/api/src/database/migrations/1723113193873-migration.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migration1723113193873 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO notify_master_providers (name,provider_type,configuration) VALUES (?, ?, ?)`,
+      [
+        'SMS_SNS',
+        4,
+        '{"AWS_ACCESS_KEY_ID":{"label":"AWS ACCESS KEY ID","id":"AWS_ACCESS_KEY_ID","pattern":"^[A-Z0-9]{20}$","type":"string"},"AWS_SECRET_ACCESS_KEY":{"label":"AWS SECRET ACCESS KEY","id":"AWS_SECRET_ACCESS_KEY","pattern":"^[A-Za-z0-9/+=]{40}$","type":"string"},"AWS_REGION":{"label":"AWS REGION","id":"AWS_REGION","pattern":"^[a-z]{2}-[a-z]+-\\d$","type":"string"}}',
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            DELETE FROM notify_master_providers
+            WHERE name = 'SMS_SNS' AND provider_type = 4;
+          `);
+  }
+}

--- a/apps/api/src/jobs/consumers/notifications/smsSns-notifications.job.consumer.ts
+++ b/apps/api/src/jobs/consumers/notifications/smsSns-notifications.job.consumer.ts
@@ -7,6 +7,7 @@ import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { WebhookService } from 'src/modules/webhook/webhook.service';
 import { SmsSnsData, SmsSnsService } from 'src/modules/providers/sms-sns/sms-sns.service';
+import { NotificationQueueProducer } from 'src/jobs/producers/notifications/notifications.job.producer';
 
 @Injectable()
 export class SmsSnsNotificationConsumer extends NotificationConsumer {
@@ -16,10 +17,18 @@ export class SmsSnsNotificationConsumer extends NotificationConsumer {
     private readonly smsSnsService: SmsSnsService,
     @Inject(forwardRef(() => NotificationsService))
     notificationsService: NotificationsService,
+    @Inject(forwardRef(() => NotificationQueueProducer))
+    notificationsQueueService: NotificationQueueProducer,
     configService: ConfigService,
     webhookService: WebhookService,
   ) {
-    super(notificationRepository, notificationsService, webhookService, configService);
+    super(
+      notificationRepository,
+      notificationsService,
+      notificationsQueueService,
+      webhookService,
+      configService,
+    );
   }
 
   async processSmsSnsNotificationQueue(id: number): Promise<void> {

--- a/apps/api/src/jobs/consumers/notifications/smsSns-notifications.job.consumer.ts
+++ b/apps/api/src/jobs/consumers/notifications/smsSns-notifications.job.consumer.ts
@@ -1,0 +1,34 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotificationsService } from 'src/modules/notifications/notifications.service';
+import { Notification } from 'src/modules/notifications/entities/notification.entity';
+import { NotificationConsumer } from './notification.consumer';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { WebhookService } from 'src/modules/webhook/webhook.service';
+import { SmsSnsData, SmsSnsService } from 'src/modules/providers/sms-sns/sms-sns.service';
+
+@Injectable()
+export class SmsSnsNotificationConsumer extends NotificationConsumer {
+  constructor(
+    @InjectRepository(Notification)
+    protected readonly notificationRepository: Repository<Notification>,
+    private readonly smsSnsService: SmsSnsService,
+    @Inject(forwardRef(() => NotificationsService))
+    notificationsService: NotificationsService,
+    configService: ConfigService,
+    webhookService: WebhookService,
+  ) {
+    super(notificationRepository, notificationsService, webhookService, configService);
+  }
+
+  async processSmsSnsNotificationQueue(id: number): Promise<void> {
+    return super.processNotificationQueue(id, async () => {
+      const notification = (await this.notificationsService.getNotificationById(id))[0];
+      return this.smsSnsService.sendMessage(
+        notification.data as unknown as SmsSnsData,
+        notification.providerId,
+      );
+    });
+  }
+}

--- a/apps/api/src/modules/notifications/dtos/providers/smsSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/smsSns-data.dto.ts
@@ -1,9 +1,9 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
 
 export class SmsSnsDataDto {
-  @IsString()
   @IsNotEmpty()
-  phoneNumber: string;
+  @MaxLength(16)
+  to: string;
 
   @IsString()
   @IsNotEmpty()

--- a/apps/api/src/modules/notifications/dtos/providers/smsSns-data.dto.ts
+++ b/apps/api/src/modules/notifications/dtos/providers/smsSns-data.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class SmsSnsDataDto {
+  @IsString()
+  @IsNotEmpty()
+  phoneNumber: string;
+
+  @IsString()
+  @IsNotEmpty()
+  message: string;
+}

--- a/apps/api/src/modules/notifications/notifications.module.ts
+++ b/apps/api/src/modules/notifications/notifications.module.ts
@@ -38,6 +38,8 @@ import { PushSnsModule } from '../providers/push-sns/push-sns.module';
 import { WebhookModule } from '../webhook/webhook.module';
 import { VcTwilioModule } from '../providers/vc-twilio/vc-twilio.module';
 import { VcTwilioNotificationsConsumer } from 'src/jobs/consumers/notifications/vcTwilio-notifications.job.consumer';
+import { SmsSnsNotificationConsumer } from 'src/jobs/consumers/notifications/smsSns-notifications.job.consumer';
+import { SmsSnsModule } from '../providers/sms-sns/sms-sns.module';
 
 const providerModules = [
   MailgunModule,
@@ -54,6 +56,7 @@ const providerModules = [
   ApplicationsModule,
   UsersModule,
   ProvidersModule,
+  SmsSnsModule,
 ];
 
 const consumers = [
@@ -67,6 +70,7 @@ const consumers = [
   SmsKapsystemNotificationsConsumer,
   PushSnsNotificationConsumer,
   VcTwilioNotificationsConsumer,
+  SmsSnsNotificationConsumer,
 ];
 
 @Module({

--- a/apps/api/src/modules/notifications/queues/queue.service.ts
+++ b/apps/api/src/modules/notifications/queues/queue.service.ts
@@ -175,6 +175,7 @@ export class QueueService {
         // SMS_SNS cases
         case `${QueueAction.SEND}-${ChannelType.SMS_SNS}`:
           await this.smsSnsNotificationConsumer.processSmsSnsNotificationQueue(job.data.id);
+          break;
         // WEBHOOK
         case `${QueueAction.WEBHOOK}-${ChannelType.SMTP}`:
         case `${QueueAction.WEBHOOK}-${ChannelType.MAILGUN}`:

--- a/apps/api/src/modules/notifications/queues/queue.service.ts
+++ b/apps/api/src/modules/notifications/queues/queue.service.ts
@@ -7,6 +7,7 @@ import { MailgunNotificationConsumer } from 'src/jobs/consumers/notifications/ma
 import { PushSnsNotificationConsumer } from 'src/jobs/consumers/notifications/pushSns-notifications.job.consumer';
 import { SmsKapsystemNotificationsConsumer } from 'src/jobs/consumers/notifications/smsKapsystem-notifications.job.consumer';
 import { SmsPlivoNotificationsConsumer } from 'src/jobs/consumers/notifications/smsPlivo-notifications.job.consumer';
+import { SmsSnsNotificationConsumer } from 'src/jobs/consumers/notifications/smsSns-notifications.job.consumer';
 import { SmsTwilioNotificationsConsumer } from 'src/jobs/consumers/notifications/smsTwilio-notifications.job.consumer';
 import { SmtpNotificationConsumer } from 'src/jobs/consumers/notifications/smtp-notifications.job.consumer';
 import { VcTwilioNotificationsConsumer } from 'src/jobs/consumers/notifications/vcTwilio-notifications.job.consumer';
@@ -36,6 +37,7 @@ export class QueueService {
     private readonly smsKapsystemNotificationConsumer: SmsKapsystemNotificationsConsumer,
     private readonly pushSnsNotificationConsumer: PushSnsNotificationConsumer,
     private readonly vcTwilioNotificationsConsumer: VcTwilioNotificationsConsumer,
+    private readonly smsSnsNotificationConsumer: SmsSnsNotificationConsumer,
   ) {
     this.redisConfig = {
       host: this.configService.get<string>('REDIS_HOST'),
@@ -167,6 +169,10 @@ export class QueueService {
           await this.vcTwilioNotificationsConsumer.processVcTwilioNotificationConfirmationQueue(
             job.data.id,
           );
+          break;
+        // SMS_SNS cases
+        case `${QueueAction.SEND}-${ChannelType.SMS_SNS}`:
+          await this.smsSnsNotificationConsumer.processSmsSnsNotificationQueue(job.data.id);
           break;
         default:
           this.logger.error(

--- a/apps/api/src/modules/providers/sms-sns/sms-sns.module.ts
+++ b/apps/api/src/modules/providers/sms-sns/sms-sns.module.ts
@@ -1,0 +1,12 @@
+import { Logger, Module } from '@nestjs/common';
+import { SmsSnsService } from './sms-sns.service';
+import { ConfigModule } from '@nestjs/config';
+import { ProvidersModule } from '../providers.module';
+import { ProvidersService } from '../providers.service';
+
+@Module({
+  imports: [ConfigModule, ProvidersModule],
+  providers: [SmsSnsService, ProvidersService, Logger],
+  exports: [SmsSnsService],
+})
+export class SmsSnsModule {}

--- a/apps/api/src/modules/providers/sms-sns/sms-sns.service.spec.ts
+++ b/apps/api/src/modules/providers/sms-sns/sms-sns.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SmsSnsService } from './sms-sns.service';
+
+describe('SmsSnsService', () => {
+  let service: SmsSnsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SmsSnsService],
+    }).compile();
+
+    service = module.get<SmsSnsService>(SmsSnsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/api/src/modules/providers/sms-sns/sms-sns.service.ts
+++ b/apps/api/src/modules/providers/sms-sns/sms-sns.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PublishCommandInput, PublishCommandOutput, SNS } from '@aws-sdk/client-sns';
+import { ProvidersService } from '../providers.service';
+
+export interface SmsSnsData {
+  phoneNumber: string;
+  message: string;
+}
+
+@Injectable()
+export class SmsSnsService {
+  private sns: SNS;
+
+  constructor(
+    private readonly providersService: ProvidersService,
+    private logger: Logger,
+  ) {}
+
+  async assignSnsConfig(providerId: number): Promise<void> {
+    this.logger.debug('Started assigning SNS sms client');
+    const snsConfig = await this.providersService.getConfigById(providerId);
+
+    this.sns = new SNS({
+      credentials: {
+        accessKeyId: snsConfig.AWS_ACCESS_KEY_ID as string,
+        secretAccessKey: snsConfig.AWS_SECRET_ACCESS_KEY as string,
+      },
+      region: snsConfig.AWS_REGION as string,
+    });
+  }
+
+  async sendMessage(data: SmsSnsData, providerId: number): Promise<PublishCommandOutput> {
+    await this.assignSnsConfig(providerId);
+
+    // Prepare SNS publish parameters
+    const params: PublishCommandInput = {
+      Message: data.message,
+      PhoneNumber: data.phoneNumber,
+    };
+
+    this.logger.debug('Sending SNS Sms ');
+    return this.sns.publish(params);
+  }
+}

--- a/apps/api/src/modules/providers/sms-sns/sms-sns.service.ts
+++ b/apps/api/src/modules/providers/sms-sns/sms-sns.service.ts
@@ -3,7 +3,7 @@ import { PublishCommandInput, PublishCommandOutput, SNS } from '@aws-sdk/client-
 import { ProvidersService } from '../providers.service';
 
 export interface SmsSnsData {
-  phoneNumber: string;
+  to: string;
   message: string;
 }
 
@@ -40,7 +40,7 @@ export class SmsSnsService {
     // Prepare SNS publish parameters
     const params: PublishCommandInput = {
       Message: data.message,
-      PhoneNumber: data.phoneNumber,
+      PhoneNumber: data.to,
     };
 
     try {

--- a/apps/api/src/modules/providers/sms-sns/sms-sns.service.ts
+++ b/apps/api/src/modules/providers/sms-sns/sms-sns.service.ts
@@ -18,15 +18,20 @@ export class SmsSnsService {
 
   async assignSnsConfig(providerId: number): Promise<void> {
     this.logger.debug('Started assigning SNS sms client');
-    const snsConfig = await this.providersService.getConfigById(providerId);
 
-    this.sns = new SNS({
-      credentials: {
-        accessKeyId: snsConfig.AWS_ACCESS_KEY_ID as string,
-        secretAccessKey: snsConfig.AWS_SECRET_ACCESS_KEY as string,
-      },
-      region: snsConfig.AWS_REGION as string,
-    });
+    try {
+      const snsConfig = await this.providersService.getConfigById(providerId);
+      this.sns = new SNS({
+        credentials: {
+          accessKeyId: snsConfig.AWS_ACCESS_KEY_ID as string,
+          secretAccessKey: snsConfig.AWS_SECRET_ACCESS_KEY as string,
+        },
+        region: snsConfig.AWS_REGION as string,
+      });
+    } catch (error) {
+      this.logger.error('Error assigning SNS configuration', error);
+      throw error;
+    }
   }
 
   async sendMessage(data: SmsSnsData, providerId: number): Promise<PublishCommandOutput> {
@@ -38,7 +43,12 @@ export class SmsSnsService {
       PhoneNumber: data.phoneNumber,
     };
 
-    this.logger.debug('Sending SNS Sms ');
-    return this.sns.publish(params);
+    try {
+      this.logger.debug('Sending SNS Sms');
+      return await this.sns.publish(params);
+    } catch (error) {
+      this.logger.error('Error sending SNS SMS', error);
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## API PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing using the [test suite](../../apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected.
- [ ] I have updated the required [api docs](../../apps/api/docs/) as applicable.
- [ ] I have added/updated test cases to the [test suite](../../apps/api/OsmoX.postman_collection.json) as applicable

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

This PR add support for sending sms using the sns 

**Related changes:**


- Install @aws/ses node package
- Create migration to populate master_provider details
- Create module and service file for SES provider with all the relevant functions
- Add documentation with related links for the specified provider aws ses
- Update postman collection with aws ses request queries

**Screenshots:**

NA

**Query request and response:**

```curl
curl --location 'localhost:3000/notifications' \
--header 'Content-Type: application/json' \
--header 'x-api-key: OsmoX-test-key' \
--data '{
    "providerId": 12,
    "data": {

        "to": "+919234567890",
        "message": "This is a test notification"
    }
}'
```
**Documentation changes:**

NA

**Test suite output:**

NA

**Pending actions:**

NA

**Additional notes:**

NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for sending SMS notifications via AWS SNS.
	- Added a new service for handling SMS notifications and integration with the notification system.
	- Comprehensive documentation for AWS SNS SMS messaging integration.

- **Enhancements**
	- Enhanced validation for SMS notification data.
	- Improved the API request collection with new entries and testing capabilities for SMS notifications.
	- Expanded notification channel options with the addition of SMS via SNS.

- **Bug Fixes**
	- Adjusted various configurations and error handling for the new SMS channel type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->