### PR TITLE
docs: update api documentation

### DIFF
--- a/apps/api/OsmoX-API.postman_collection.json
+++ b/apps/api/OsmoX-API.postman_collection.json
@@ -980,7 +980,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query {\r\n  providers(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      sortOrder: ASC\r\n    }\r\n  ) {\r\n    providers {\r\n        providerId\r\n        name\r\n        channelType\r\n        configuration\r\n        isEnabled\r\n        userId\r\n        createdOn\r\n        updatedOn\r\n        status\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}",
+								"query": "query {\r\n  providers(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      sortOrder: ASC\r\n    }\r\n  ) {\r\n    providers {\r\n        applicationId\r\n        providerId\r\n        name\r\n        channelType\r\n        configuration\r\n        isEnabled\r\n        userId\r\n        createdOn\r\n        updatedOn\r\n        status\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}",
 								"variables": ""
 							}
 						},

--- a/apps/api/OsmoX.postman_collection.json
+++ b/apps/api/OsmoX.postman_collection.json
@@ -4059,7 +4059,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query {\r\n  providers(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      sortOrder: ASC\r\n    }\r\n  ) {\r\n    providers {\r\n        providerId\r\n        name\r\n        channelType\r\n        configuration\r\n        isEnabled\r\n        userId\r\n        createdOn\r\n        updatedOn\r\n        status\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}",
+								"query": "query {\r\n  providers(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      sortOrder: ASC\r\n    }\r\n  ) {\r\n    providers {\r\n        applicationId\r\n        providerId\r\n        name\r\n        channelType\r\n        configuration\r\n        isEnabled\r\n        userId\r\n        createdOn\r\n        updatedOn\r\n        status\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}",
 								"variables": ""
 							}
 						},
@@ -4122,7 +4122,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query {\r\n  providers(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      sortOrder: ASC\r\n    }\r\n  ) {\r\n    providers {\r\n        providerId\r\n        name\r\n        channelType\r\n        configuration\r\n        isEnabled\r\n        userId\r\n        createdOn\r\n        updatedOn\r\n        status\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}",
+								"query": "query {\r\n  providers(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      sortOrder: ASC\r\n    }\r\n  ) {\r\n    providers {\r\n        applicationId\r\n        providerId\r\n        name\r\n        channelType\r\n        configuration\r\n        isEnabled\r\n        userId\r\n        createdOn\r\n        updatedOn\r\n        status\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}",
 								"variables": ""
 							}
 						},
@@ -4180,7 +4180,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query {\r\n  providers(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      unknownValue: \"Some unknown parameter\"\r\n      sortOrder: ASC\r\n    }\r\n  ) {\r\n    providers {\r\n        providerId\r\n        name\r\n        channelType\r\n        configuration\r\n        isEnabled\r\n        userId\r\n        createdOn\r\n        updatedOn\r\n        status\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}",
+								"query": "query {\r\n  providers(\r\n    options: {\r\n      limit: 5\r\n      offset: 0\r\n      sortBy: \"createdOn\"\r\n      unknownValue: \"Some unknown parameter\"\r\n      sortOrder: ASC\r\n    }\r\n  ) {\r\n    providers {\r\n        applicationId\r\n        providerId\r\n        name\r\n        channelType\r\n        configuration\r\n        isEnabled\r\n        userId\r\n        createdOn\r\n        updatedOn\r\n        status\r\n    }\r\n    total,\r\n    offset,\r\n    limit\r\n  }\r\n}",
 								"variables": ""
 							}
 						},

--- a/apps/api/docs/api-documentation.md
+++ b/apps/api/docs/api-documentation.md
@@ -167,11 +167,13 @@ curl --location 'http://localhost:3000/notifications' \
       "createdBy": "sampleFoundationApp",
       "updatedBy": "sampleFoundationApp",
       "result": null,
+      "notificationSentOn": null,
       "id": 92,
       "deliveryStatus": 1,
       "createdOn": "2024-02-12T07:24:21.000Z",
       "updatedOn": "2024-02-12T07:24:21.000Z",
-      "status": 1
+      "status": 1,
+      "retryCount": 0
     }
   }
 }

--- a/apps/api/docs/channels/vc-twilio.md
+++ b/apps/api/docs/channels/vc-twilio.md
@@ -38,8 +38,8 @@ Here's a sample request body:
         "from": "+15005550006",  // The phone number, SIP address, or client identifier to call
         "to": "+91xxxxxxxxxx",  // The phone number or client identifier to use as the caller id
         // Set either `url` or `twiml`. If both are provided then `twiml` parameter will be ignored.
-        "url": "http://your-server-url/calls/message",  // TwiML instructions for the call Twilio will use without fetching Twiml from url parameter. Max 4000 characters
-        "twiml": "<Response><Say>Hello there!</Say></Response>" // The SID of the Application resource that will handle the call, if the call will be handled by an application
+        "url": "http://your-server-url/calls/message",  // The absolute URL that returns the TwiML instructions for the call. We will call this URL using the `method` when the call connects. For more information, see the [Url Parameter](https://www.twilio.com/docs/voice/make-calls#specify-a-url-parameter) section in [Making Calls](https://www.twilio.com/docs/voice/make-calls).
+        "twiml": "<Response><Say>Hello there!</Say></Response>" // TwiML instructions for the call Twilio will use without fetching Twiml from url parameter. Max 4000 characters.
     }
 }
 ```

--- a/apps/api/docs/usage-guide.md
+++ b/apps/api/docs/usage-guide.md
@@ -99,12 +99,13 @@ Replace `SERVER_API_KEY_VALUE` with the actual API key value you want to include
       "createdBy": "OsmoX",
       "updatedBy": "OsmoX",
       "result": null,
-      "id": 36,
       "notificationSentOn": null,
+      "id": 36,
       "deliveryStatus": 1,
       "createdOn": "2023-09-08T13:11:52.000Z",
       "updatedOn": "2023-09-08T13:11:52.000Z",
-      "status": 1
+      "status": 1,
+      "retryCount": 0
     }
   }
 }


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-299](https://pinestem.com/dashboard.html#/tasks/OSXT-299/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have performed preliminary testing to ensure that any existing features are not impacted and any new features are working as expected as a whole.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login page`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional, may include unit testing screenshots as well)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

Add notificationSentOn where it was missing in documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to include new `"notificationSentOn"` and `"retryCount"` fields in notification JSON responses.
  - Clarified the description of the `url` parameter in Twilio Voice Call request samples.
- **New Features**
  - Expanded GraphQL queries in Postman collections to retrieve the `"applicationId"` field within provider data responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->