### PR TITLE
refactor: 360Dialog error handling

### DIFF
--- a/apps/api/src/modules/providers/wa360dialog/wa360dialog.service.ts
+++ b/apps/api/src/modules/providers/wa360dialog/wa360dialog.service.ts
@@ -1,7 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
 import { ProvidersService } from '../providers.service';
-import { lastValueFrom } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 
 export interface Wa360DialogData {
   to: string;
@@ -69,16 +69,22 @@ export class Wa360dialogService {
         'Content-Type': 'application/json',
       };
       this.logger.debug('Sending 360Dialog Whatsapp');
-      const response = await lastValueFrom(this.httpService.post(this.apiUrl, body, { headers }));
+      const response = await firstValueFrom(this.httpService.post(this.apiUrl, body, { headers }));
       return response.data;
     } catch (error) {
       if (error.response) {
-        const providerResponseError = {
-          status: error.response.status,
-          statusText: error.response.statusText,
-        };
-        // Log relevant parts of the error response
-        this.logger.error(`Error sent from provider: ${providerId}`, providerResponseError);
+        // Log bad request
+        if (error.response.status && error.response.status === 400) {
+          this.logger.log(
+            `Bad Request exception sent from provider: ${providerId} - (${error.response.status}): ${JSON.stringify(error.response.data ?? 'No Data')}`,
+          );
+        } else {
+          // Log relevant parts of the error response
+          this.logger.error(
+            `Error sent from provider: ${providerId} - (${error.response.status ?? 'No Status'} ${error.response.statusText ?? 'No StatusTest'}): ${JSON.stringify(error.response.data ?? 'No Data')}`,
+            error.stack,
+          );
+        }
 
         throw error;
       } else {


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-300](https://pinestem.com/dashboard.html#/tasks/OSXT-300/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [ ] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [ ] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [ ] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [ ] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [ ] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [ ] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

- Handle all error with responses separately
- Use `logger.log` for 400 bad request exceptions
- Use `logger.error`  for all other errors
- Use `firstValueFrom` for sending POST request to 360Dialog

**Screenshots:**

![image](https://github.com/user-attachments/assets/b44f6746-a8db-4892-8932-d3dc1620c17f)

```json
[{"timestamp":"1","level":"2","severity":"3","tracebackId":"4","source":"5","message":"6"},"2025-04-22T09:13:24.503Z","info","low","cedbc91b-2877-4245-b2cc-9ad2811c787b","Wa360dialogNotificationsConsumer","Sending notification with id: 231"]
[{"timestamp":"1","level":"2","severity":"3","tracebackId":"4","source":"5","message":"6"},"2025-04-22T09:13:24.503Z","info","low","15caac5f-a3d5-470f-b67c-26c1a2ba9e7b","NotificationsService","Getting notification with id: 231"]
[{"timestamp":"1","level":"2","severity":"3","tracebackId":"4","message":"5"},"2025-04-22T09:13:24.777Z","info","low","73bd06ed-69b9-4ed3-bf0a-0b2093869e30","Bad Request exception sent from provider: 3 - (400): {\"meta\":{\"api_status\":\"stable\",\"version\":\"2.61.1\"},\"errors\":[{\"code\":2000,\"title\":\"Number of parameters does not match the expected number of params\",\"details\":\"number of localizable_params (4) does not match the expected number of params (9)\",\"href\":\"https://developers.facebook.com/docs/whatsapp/faq#faq_1612022582274564\"}]}"]
[{"timestamp":"1","level":"2","severity":"3","tracebackId":"4","source":"5","message":"6"},"2025-04-22T09:13:24.777Z","info","low","920eca39-d849-4e73-9c68-fde338f9ae9a","Wa360dialogNotificationsConsumer","Notification with ID 231 has attempted max allowed retries (sending), setting delivery status to 6"]
[{"timestamp":"1","level":"2","severity":"3","tracebackId":"4","source":"5","message":"6"},"2025-04-22T09:13:24.784Z","info","low","0a58ef21-1bd3-4f84-8fa5-c9a4cfc1f639","QueueService","Creating new queue and worker for webhook-3-3"]
[{"timestamp":"1","level":"2","severity":"3","tracebackId":"4","source":"5","message":"6","stackTrace":"7"},"2025-04-22T09:13:24.794Z","error","high","55af8f62-7089-4233-bfdb-2996fcdbbb29","Wa360dialogNotificationsConsumer","Error sending notification with id: 231",[null]]
[{"timestamp":"1","level":"2","severity":"3","tracebackId":"4","source":"5","message":"6","stackTrace":"7"},"2025-04-22T09:13:24.794Z","error","high","dae6a133-2dff-4839-933a-cc35cdd2fc42","Wa360dialogNotificationsConsumer","{\n  \"message\": \"Request failed with status code 400\",\n  \"stack\": \"AxiosError: Request failed with status code 400\\n    at settle (/home/osmo-x/apps/api/node_modules/axios/lib/core/settle.js:19:12)\\n    at IncomingMessage.handleStreamEnd (/home/osmo-x/apps/api/node_modules/axios/lib/adapters/http.js:599:11)\\n    at IncomingMessage.emit (node:events:530:35)\\n    at endReadableNT (node:internal/streams/readable:1698:12)\\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)\\n    at Axios.request (/home/osmo-x/apps/api/node_modules/axios/lib/core/Axios.js:45:41)\\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\"\n}",[null]]
[{"timestamp":"1","level":"2","severity":"3","tracebackId":"4","source":"5","message":"6"},"2025-04-22T09:13:24.798Z","info","low","f2da2462-8262-43c8-b934-9275d2cc5099","NotificationsService","Getting notification with id: 231"]
```
