### PR TITLE
fix: search for notifiers on portal using PostgreSQL

### DIFF
--- a/apps/api/src/common/graphql/services/core.service.ts
+++ b/apps/api/src/common/graphql/services/core.service.ts
@@ -55,7 +55,11 @@ export abstract class CoreService<TEntity> {
       queryBuilder.andWhere(
         new Brackets((qb) => {
           searchableFields.forEach((field) => {
-            qb.orWhere(`${alias}.${field} LIKE :search`, { search: `%${options.search}%` });
+            this.isJsonbColumn(field)
+              ? qb.orWhere(`CAST(${alias}.${field} AS text) LIKE :search`, {
+                  search: `%${options.search}%`,
+                })
+              : qb.orWhere(`${alias}.${field} LIKE :search`, { search: `%${options.search}%` });
           });
         }),
       );

--- a/apps/api/src/common/graphql/services/core.service.ts
+++ b/apps/api/src/common/graphql/services/core.service.ts
@@ -78,7 +78,8 @@ export abstract class CoreService<TEntity> {
           condition += ` = :${paramName}`;
           break;
         case 'contains':
-          condition += ` LIKE :${paramName}`;
+          // PostgreSQL-specific: cast jsonb field to text to allow pattern matching
+          condition = `CAST(${alias}.${field} AS text) LIKE :${paramName}`;
           break;
         case 'gt':
           condition += ` > :${paramName}`;

--- a/apps/api/src/common/graphql/services/core.service.ts
+++ b/apps/api/src/common/graphql/services/core.service.ts
@@ -11,8 +11,15 @@ export abstract class CoreService<TEntity> {
   // List of date fields for comparison handling
   private dateFields: string[] = ['createdOn', 'updatedOn']; // Customize based on your entity fields
 
+  // List of jsonb fields used for data search
+  private jsonbFields: string[] = ['data', 'result', 'configuration', 'whitelistRecipients']; // Customize based on your entity fields
+
   private isDateField(field: string): boolean {
     return this.dateFields.includes(field);
+  }
+
+  private isJsonbColumn(field: string): boolean {
+    return this.jsonbFields.includes(field);
   }
 
   async findAll(
@@ -78,8 +85,10 @@ export abstract class CoreService<TEntity> {
           condition += ` = :${paramName}`;
           break;
         case 'contains':
-          // PostgreSQL-specific: cast jsonb field to text to allow pattern matching
-          condition = `CAST(${alias}.${field} AS text) LIKE :${paramName}`;
+          // Only cast jsonb fields in Postgres
+          condition = this.isJsonbColumn(field)
+            ? `CAST(${alias}.${field} AS text) LIKE :${paramName}`
+            : `${alias}.${field} LIKE :${paramName}`;
           break;
         case 'gt':
           condition += ` > :${paramName}`;


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-319](https://pinestem.com/dashboard.html#/tasks/OSXT-319/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [x] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [x] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

API requests can now search for notifiers (or any keyword) in `jsonb` datatype fields

**Related Changes:**

- PostgreSQL uses `jsonb` fields that need to be cast to text for using the `LIKE` operator
- Create static list of `jsonb` fields osmox uses
- Update `core.service` to cast all `jsonb` fields to text then perform `LIKE` operation
- Similarly fix the `search` graphql option for jsonb fields
- Tested with varchar datatypes - working
- Test locally & on dockerized environment

**Additional Notes:**

- The change is for PostgreSQL database only, we would need to revert it if shifting databases
- Ideally we want a way to detect if the field has jsonb as datatype, but could not find a suitable method so created array of jsonb fields to check instead.
- If we want to use `findAll` function for any other entity, the `jsonb` fields for said entity should be added in `jsonbFields` array

**Screenshots:**

Active
![image](https://github.com/user-attachments/assets/0c6d5a28-f26d-4d1f-a65c-8c723c3e54d0)

Archived
![image](https://github.com/user-attachments/assets/91945c2b-2588-440e-a7a0-4ce3095d115c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for pattern matching on JSON fields, ensuring more accurate search results when using the "contains" filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->