### PR TITLE
chore: migration for fallback provider feature

### DIFF
--- a/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
+++ b/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
@@ -1,0 +1,359 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableColumn,
+  TableForeignKey,
+  TableIndex,
+  TableUnique,
+} from 'typeorm';
+
+export class FallbackProviderChanges1751022743600 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Create notify_provider_chains table
+    await queryRunner.createTable(
+      new Table({
+        name: 'notify_provider_chains',
+        columns: [
+          {
+            name: 'chain_id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'chain_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'application_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'channel_type',
+            type: 'smallint',
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'is_default',
+            type: 'smallint',
+            default: '0',
+            isNullable: false,
+          },
+          {
+            name: 'created_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'smallint',
+            default: '1',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    // 2. Create notify_provider_chain_members table
+    await queryRunner.createTable(
+      new Table({
+        name: 'notify_provider_chain_members',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'chain_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'provider_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'priority_order',
+            type: 'smallint',
+            isNullable: false,
+          },
+          {
+            name: 'is_active',
+            type: 'smallint',
+            default: '1',
+            isNullable: false,
+          },
+          {
+            name: 'created_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'smallint',
+            default: '1',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    // 3. Add Foreign Key Constraints for notify_provider_chains
+    await queryRunner.createForeignKey(
+      'notify_provider_chains',
+      new TableForeignKey({
+        columnNames: ['application_id'],
+        referencedColumnNames: ['application_id'],
+        referencedTableName: 'notify_applications',
+        onDelete: 'CASCADE',
+        name: 'FK_PROVIDER_CHAINS_APPLICATION',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notify_provider_chains',
+      new TableForeignKey({
+        columnNames: ['channel_type'],
+        referencedColumnNames: ['master_id'],
+        referencedTableName: 'notify_master_providers',
+        onDelete: 'CASCADE',
+        name: 'FK_PROVIDER_CHAINS_CHANNEL_TYPE',
+      }),
+    );
+
+    // 4. Add Foreign Key Constraints for notify_provider_chain_members
+    await queryRunner.createForeignKey(
+      'notify_provider_chain_members',
+      new TableForeignKey({
+        columnNames: ['chain_id'],
+        referencedColumnNames: ['chain_id'],
+        referencedTableName: 'notify_provider_chains',
+        onDelete: 'CASCADE',
+        name: 'FK_CHAIN_MEMBERS_CHAIN',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notify_provider_chain_members',
+      new TableForeignKey({
+        columnNames: ['provider_id'],
+        referencedColumnNames: ['provider_id'],
+        referencedTableName: 'notify_providers',
+        onDelete: 'CASCADE',
+        name: 'FK_CHAIN_MEMBERS_PROVIDER',
+      }),
+    );
+
+    // 4. Create Indexes for notify_provider_chains
+    await queryRunner.createIndex(
+      'notify_provider_chains',
+      new TableIndex({
+        columnNames: ['application_id', 'channel_type'],
+        name: 'IDX_CHAINS_APPLICATION_CHANNEL',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_provider_chains',
+      new TableIndex({
+        columnNames: ['status'],
+        name: 'IDX_CHAINS_STATUS',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_provider_chains',
+      new TableIndex({
+        columnNames: ['application_id', 'channel_type', 'is_default'],
+        name: 'IDX_CHAINS_DEFAULT',
+      }),
+    );
+
+    // 5. Create Indexes for notify_provider_chain_members
+    await queryRunner.createIndex(
+      'notify_provider_chain_members',
+      new TableIndex({
+        columnNames: ['chain_id', 'priority_order'],
+        name: 'IDX_CHAIN_MEMBERS_CHAIN_ORDER',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_provider_chain_members',
+      new TableIndex({
+        columnNames: ['provider_id'],
+        name: 'IDX_CHAIN_MEMBERS_PROVIDER',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_provider_chain_members',
+      new TableIndex({
+        columnNames: ['status'],
+        name: 'IDX_CHAIN_MEMBERS_STATUS',
+      }),
+    );
+
+    // 6. Add Unique Constraints for both tables
+    await queryRunner.createUniqueConstraint(
+      'notify_provider_chains',
+      new TableUnique({
+        columnNames: ['application_id', 'chain_name'],
+        name: 'UQ_APP_CHAIN_NAME',
+      }),
+    );
+
+    await queryRunner.createUniqueConstraint(
+      'notify_provider_chain_members',
+      new TableUnique({
+        columnNames: ['chain_id', 'priority_order'],
+        name: 'UQ_CHAIN_PRIORITY',
+      }),
+    );
+
+    await queryRunner.createUniqueConstraint(
+      'notify_provider_chain_members',
+      new TableUnique({
+        columnNames: ['chain_id', 'provider_id'],
+        name: 'UQ_CHAIN_PROVIDER',
+      }),
+    );
+
+    // 7. Table modifications for notify_notifications
+    await queryRunner.addColumn(
+      'notify_notifications',
+      new TableColumn({
+        name: 'provider_chain_id',
+        type: 'int',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notify_notifications',
+      new TableForeignKey({
+        columnNames: ['provider_chain_id'],
+        referencedColumnNames: ['chain_id'],
+        referencedTableName: 'notify_provider_chains',
+        onDelete: 'SET NULL',
+        name: 'FK_NOTIFICATIONS_PROVIDER_CHAIN',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_notifications',
+      new TableIndex({
+        columnNames: ['provider_chain_id'],
+        name: 'IDX_NOTIFICATIONS_PROVIDER_CHAIN',
+      }),
+    );
+
+    // 8. Table modifications for notify_archived_notifications
+    await queryRunner.addColumn(
+      'notify_archived_notifications',
+      new TableColumn({
+        name: 'provider_chain_id',
+        type: 'int',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notify_archived_notifications',
+      new TableForeignKey({
+        columnNames: ['provider_chain_id'],
+        referencedColumnNames: ['chain_id'],
+        referencedTableName: 'notify_provider_chains',
+        onDelete: 'SET NULL',
+        name: 'FK_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_archived_notifications',
+      new TableIndex({
+        columnNames: ['provider_chain_id'],
+        name: 'IDX_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    {
+      // 1. Revert changes from table notify_archived_notifications
+      await queryRunner.dropIndex(
+        'notify_archived_notifications',
+        'IDX_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+      );
+      await queryRunner.dropForeignKey(
+        'notify_archived_notifications',
+        'FK_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+      );
+      await queryRunner.dropColumn('notify_archived_notifications', 'provider_chain_id');
+
+      // 2. Revert changes from table notify_notifications
+      await queryRunner.dropIndex('notify_notifications', 'IDX_NOTIFICATIONS_PROVIDER_CHAIN');
+      await queryRunner.dropForeignKey('notify_notifications', 'FK_NOTIFICATIONS_PROVIDER_CHAIN');
+      await queryRunner.dropColumn('notify_notifications', 'provider_chain_id');
+
+      // 3. Drop Unique Constraints
+      await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PROVIDER');
+      await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PRIORITY');
+      await queryRunner.dropUniqueConstraint('notify_provider_chains', 'UQ_APP_CHAIN_NAME');
+
+      // 4. Drop Indexes
+      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_STATUS');
+      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_PROVIDER');
+      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_CHAIN_ORDER');
+
+      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_DEFAULT');
+      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_STATUS');
+      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_APPLICATION_CHANNEL');
+
+      // 5. Drop Foreign Key Constraints
+      await queryRunner.dropForeignKey(
+        'notify_provider_chain_members',
+        'FK_CHAIN_MEMBERS_PROVIDER',
+      );
+      await queryRunner.dropForeignKey('notify_provider_chain_members', 'FK_CHAIN_MEMBERS_CHAIN');
+      await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_CHANNEL_TYPE');
+      await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_APPLICATION');
+
+      // 6. Drop tables in reverse order of creation to respect dependencies
+      await queryRunner.dropTable('notify_provider_chain_members');
+      await queryRunner.dropTable('notify_provider_chains');
+    }
+  }
+}

--- a/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
+++ b/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
@@ -176,7 +176,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 4. Create Indexes for notify_provider_chains
+    // 5. Create Indexes for notify_provider_chains
     await queryRunner.createIndex(
       'notify_provider_chains',
       new TableIndex({
@@ -201,7 +201,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 5. Create Indexes for notify_provider_chain_members
+    // 6. Create Indexes for notify_provider_chain_members
     await queryRunner.createIndex(
       'notify_provider_chain_members',
       new TableIndex({
@@ -226,7 +226,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 6. Add Unique Constraints for both tables
+    // 7. Add Unique Constraints for both tables
     await queryRunner.createUniqueConstraint(
       'notify_provider_chains',
       new TableUnique({
@@ -251,7 +251,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 7. Table modifications for notify_notifications
+    // 8. Table modifications for notify_notifications
     await queryRunner.addColumn(
       'notify_notifications',
       new TableColumn({
@@ -280,7 +280,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 8. Table modifications for notify_archived_notifications
+    // 9. Table modifications for notify_archived_notifications
     await queryRunner.addColumn(
       'notify_archived_notifications',
       new TableColumn({

--- a/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
+++ b/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
@@ -311,49 +311,44 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    {
-      // 1. Revert changes from table notify_archived_notifications
-      await queryRunner.dropIndex(
-        'notify_archived_notifications',
-        'IDX_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
-      );
-      await queryRunner.dropForeignKey(
-        'notify_archived_notifications',
-        'FK_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
-      );
-      await queryRunner.dropColumn('notify_archived_notifications', 'provider_chain_id');
+    // 1. Revert changes from table notify_archived_notifications
+    await queryRunner.dropIndex(
+      'notify_archived_notifications',
+      'IDX_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+    );
+    await queryRunner.dropForeignKey(
+      'notify_archived_notifications',
+      'FK_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+    );
+    await queryRunner.dropColumn('notify_archived_notifications', 'provider_chain_id');
 
-      // 2. Revert changes from table notify_notifications
-      await queryRunner.dropIndex('notify_notifications', 'IDX_NOTIFICATIONS_PROVIDER_CHAIN');
-      await queryRunner.dropForeignKey('notify_notifications', 'FK_NOTIFICATIONS_PROVIDER_CHAIN');
-      await queryRunner.dropColumn('notify_notifications', 'provider_chain_id');
+    // 2. Revert changes from table notify_notifications
+    await queryRunner.dropIndex('notify_notifications', 'IDX_NOTIFICATIONS_PROVIDER_CHAIN');
+    await queryRunner.dropForeignKey('notify_notifications', 'FK_NOTIFICATIONS_PROVIDER_CHAIN');
+    await queryRunner.dropColumn('notify_notifications', 'provider_chain_id');
 
-      // 3. Drop Unique Constraints
-      await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PROVIDER');
-      await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PRIORITY');
-      await queryRunner.dropUniqueConstraint('notify_provider_chains', 'UQ_APP_CHAIN_NAME');
+    // 3. Drop Unique Constraints
+    await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PROVIDER');
+    await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PRIORITY');
+    await queryRunner.dropUniqueConstraint('notify_provider_chains', 'UQ_APP_CHAIN_NAME');
 
-      // 4. Drop Indexes
-      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_STATUS');
-      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_PROVIDER');
-      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_CHAIN_ORDER');
+    // 4. Drop Indexes
+    await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_STATUS');
+    await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_PROVIDER');
+    await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_CHAIN_ORDER');
 
-      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_DEFAULT');
-      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_STATUS');
-      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_APPLICATION_CHANNEL');
+    await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_DEFAULT');
+    await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_STATUS');
+    await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_APPLICATION_CHANNEL');
 
-      // 5. Drop Foreign Key Constraints
-      await queryRunner.dropForeignKey(
-        'notify_provider_chain_members',
-        'FK_CHAIN_MEMBERS_PROVIDER',
-      );
-      await queryRunner.dropForeignKey('notify_provider_chain_members', 'FK_CHAIN_MEMBERS_CHAIN');
-      await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_CHANNEL_TYPE');
-      await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_APPLICATION');
+    // 5. Drop Foreign Key Constraints
+    await queryRunner.dropForeignKey('notify_provider_chain_members', 'FK_CHAIN_MEMBERS_PROVIDER');
+    await queryRunner.dropForeignKey('notify_provider_chain_members', 'FK_CHAIN_MEMBERS_CHAIN');
+    await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_CHANNEL_TYPE');
+    await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_APPLICATION');
 
-      // 6. Drop tables in reverse order of creation to respect dependencies
-      await queryRunner.dropTable('notify_provider_chain_members');
-      await queryRunner.dropTable('notify_provider_chains');
-    }
+    // 6. Drop tables in reverse order of creation to respect dependencies
+    await queryRunner.dropTable('notify_provider_chain_members');
+    await queryRunner.dropTable('notify_provider_chains');
   }
 }


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-337](https://pinestem.com/dashboard.html#/tasks/OSXT-337/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [x] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

Add migration file for fallback provider feature

**Related Changes:**

- Create new table notify_provider_chains
- Create new table notify_provider_chain_members
- Add foreign key constraints
- Add indexes
- Update table notify_notifications to have foreign key and indexes on newly added column provider_chain_id
- Update table notify_archived_notifications to have foreign key and indexes on newly added column provider_chain_id

**Screenshots:**

![osmox-postgres-local - public](https://github.com/user-attachments/assets/c1cf495b-96c4-422d-be90-cc8add075f30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for managing provider chains and their members, enabling enhanced organization and prioritization of notification providers.

* **Improvements**
  * Added the ability to associate notifications with specific provider chains for better tracking and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->