### PR TITLE
feat: configure entities for fallback provider chains

### DIFF
--- a/apps/api/src/common/constants/database.ts
+++ b/apps/api/src/common/constants/database.ts
@@ -21,3 +21,8 @@ export const IsEnabledStatus = {
   FALSE: 0,
   TRUE: 1,
 };
+
+export const IsDefaultStatus = {
+  FALSE: 0,
+  TRUE: 1,
+};

--- a/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
+++ b/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
@@ -1,0 +1,359 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableColumn,
+  TableForeignKey,
+  TableIndex,
+  TableUnique,
+} from 'typeorm';
+
+export class FallbackProviderChanges1751022743600 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Create notify_provider_chains table
+    await queryRunner.createTable(
+      new Table({
+        name: 'notify_provider_chains',
+        columns: [
+          {
+            name: 'chain_id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'chain_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'application_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'channel_type',
+            type: 'smallint',
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'is_default',
+            type: 'smallint',
+            default: '0',
+            isNullable: false,
+          },
+          {
+            name: 'created_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'smallint',
+            default: '1',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    // 2. Create notify_provider_chain_members table
+    await queryRunner.createTable(
+      new Table({
+        name: 'notify_provider_chain_members',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'chain_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'provider_id',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'priority_order',
+            type: 'smallint',
+            isNullable: false,
+          },
+          {
+            name: 'is_active',
+            type: 'smallint',
+            default: '1',
+            isNullable: false,
+          },
+          {
+            name: 'created_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'smallint',
+            default: '1',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    // 3. Add Foreign Key Constraints for notify_provider_chains
+    await queryRunner.createForeignKey(
+      'notify_provider_chains',
+      new TableForeignKey({
+        columnNames: ['application_id'],
+        referencedColumnNames: ['application_id'],
+        referencedTableName: 'notify_applications',
+        onDelete: 'CASCADE',
+        name: 'FK_PROVIDER_CHAINS_APPLICATION',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notify_provider_chains',
+      new TableForeignKey({
+        columnNames: ['channel_type'],
+        referencedColumnNames: ['master_id'],
+        referencedTableName: 'notify_master_providers',
+        onDelete: 'CASCADE',
+        name: 'FK_PROVIDER_CHAINS_CHANNEL_TYPE',
+      }),
+    );
+
+    // 4. Add Foreign Key Constraints for notify_provider_chain_members
+    await queryRunner.createForeignKey(
+      'notify_provider_chain_members',
+      new TableForeignKey({
+        columnNames: ['chain_id'],
+        referencedColumnNames: ['chain_id'],
+        referencedTableName: 'notify_provider_chains',
+        onDelete: 'CASCADE',
+        name: 'FK_CHAIN_MEMBERS_CHAIN',
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notify_provider_chain_members',
+      new TableForeignKey({
+        columnNames: ['provider_id'],
+        referencedColumnNames: ['provider_id'],
+        referencedTableName: 'notify_providers',
+        onDelete: 'CASCADE',
+        name: 'FK_CHAIN_MEMBERS_PROVIDER',
+      }),
+    );
+
+    // 4. Create Indexes for notify_provider_chains
+    await queryRunner.createIndex(
+      'notify_provider_chains',
+      new TableIndex({
+        columnNames: ['application_id', 'channel_type'],
+        name: 'IDX_CHAINS_APPLICATION_CHANNEL',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_provider_chains',
+      new TableIndex({
+        columnNames: ['status'],
+        name: 'IDX_CHAINS_STATUS',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_provider_chains',
+      new TableIndex({
+        columnNames: ['application_id', 'channel_type', 'is_default'],
+        name: 'IDX_CHAINS_DEFAULT',
+      }),
+    );
+
+    // 5. Create Indexes for notify_provider_chain_members
+    await queryRunner.createIndex(
+      'notify_provider_chain_members',
+      new TableIndex({
+        columnNames: ['chain_id', 'priority_order'],
+        name: 'IDX_CHAIN_MEMBERS_CHAIN_ORDER',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_provider_chain_members',
+      new TableIndex({
+        columnNames: ['provider_id'],
+        name: 'IDX_CHAIN_MEMBERS_PROVIDER',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_provider_chain_members',
+      new TableIndex({
+        columnNames: ['status'],
+        name: 'IDX_CHAIN_MEMBERS_STATUS',
+      }),
+    );
+
+    // 6. Add Unique Constraints for both tables
+    await queryRunner.createUniqueConstraint(
+      'notify_provider_chains',
+      new TableUnique({
+        columnNames: ['application_id', 'chain_name'],
+        name: 'UQ_APP_CHAIN_NAME',
+      }),
+    );
+
+    await queryRunner.createUniqueConstraint(
+      'notify_provider_chain_members',
+      new TableUnique({
+        columnNames: ['chain_id', 'priority_order'],
+        name: 'UQ_CHAIN_PRIORITY',
+      }),
+    );
+
+    await queryRunner.createUniqueConstraint(
+      'notify_provider_chain_members',
+      new TableUnique({
+        columnNames: ['chain_id', 'provider_id'],
+        name: 'UQ_CHAIN_PROVIDER',
+      }),
+    );
+
+    // 7. Table modifications for notify_notifications
+    await queryRunner.addColumn(
+      'notify_notifications',
+      new TableColumn({
+        name: 'provider_chain_id',
+        type: 'int',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notify_notifications',
+      new TableForeignKey({
+        columnNames: ['provider_chain_id'],
+        referencedColumnNames: ['chain_id'],
+        referencedTableName: 'notify_provider_chains',
+        onDelete: 'SET NULL',
+        name: 'FK_NOTIFICATIONS_PROVIDER_CHAIN',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_notifications',
+      new TableIndex({
+        columnNames: ['provider_chain_id'],
+        name: 'IDX_NOTIFICATIONS_PROVIDER_CHAIN',
+      }),
+    );
+
+    // 8. Table modifications for notify_archived_notifications
+    await queryRunner.addColumn(
+      'notify_archived_notifications',
+      new TableColumn({
+        name: 'provider_chain_id',
+        type: 'int',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notify_archived_notifications',
+      new TableForeignKey({
+        columnNames: ['provider_chain_id'],
+        referencedColumnNames: ['chain_id'],
+        referencedTableName: 'notify_provider_chains',
+        onDelete: 'SET NULL',
+        name: 'FK_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notify_archived_notifications',
+      new TableIndex({
+        columnNames: ['provider_chain_id'],
+        name: 'IDX_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    {
+      // 1. Revert changes from table notify_archived_notifications
+      await queryRunner.dropIndex(
+        'notify_archived_notifications',
+        'IDX_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+      );
+      await queryRunner.dropForeignKey(
+        'notify_archived_notifications',
+        'FK_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+      );
+      await queryRunner.dropColumn('notify_archived_notifications', 'provider_chain_id');
+
+      // 2. Revert changes from table notify_notifications
+      await queryRunner.dropIndex('notify_notifications', 'IDX_NOTIFICATIONS_PROVIDER_CHAIN');
+      await queryRunner.dropForeignKey('notify_notifications', 'FK_NOTIFICATIONS_PROVIDER_CHAIN');
+      await queryRunner.dropColumn('notify_notifications', 'provider_chain_id');
+
+      // 3. Drop Unique Constraints
+      await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PROVIDER');
+      await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PRIORITY');
+      await queryRunner.dropUniqueConstraint('notify_provider_chains', 'UQ_APP_CHAIN_NAME');
+
+      // 4. Drop Indexes
+      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_STATUS');
+      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_PROVIDER');
+      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_CHAIN_ORDER');
+
+      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_DEFAULT');
+      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_STATUS');
+      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_APPLICATION_CHANNEL');
+
+      // 5. Drop Foreign Key Constraints
+      await queryRunner.dropForeignKey(
+        'notify_provider_chain_members',
+        'FK_CHAIN_MEMBERS_PROVIDER',
+      );
+      await queryRunner.dropForeignKey('notify_provider_chain_members', 'FK_CHAIN_MEMBERS_CHAIN');
+      await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_CHANNEL_TYPE');
+      await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_APPLICATION');
+
+      // 6. Drop tables in reverse order of creation to respect dependencies
+      await queryRunner.dropTable('notify_provider_chain_members');
+      await queryRunner.dropTable('notify_provider_chains');
+    }
+  }
+}

--- a/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
+++ b/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
@@ -176,7 +176,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 4. Create Indexes for notify_provider_chains
+    // 5. Create Indexes for notify_provider_chains
     await queryRunner.createIndex(
       'notify_provider_chains',
       new TableIndex({
@@ -201,7 +201,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 5. Create Indexes for notify_provider_chain_members
+    // 6. Create Indexes for notify_provider_chain_members
     await queryRunner.createIndex(
       'notify_provider_chain_members',
       new TableIndex({
@@ -226,7 +226,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 6. Add Unique Constraints for both tables
+    // 7. Add Unique Constraints for both tables
     await queryRunner.createUniqueConstraint(
       'notify_provider_chains',
       new TableUnique({
@@ -251,7 +251,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 7. Table modifications for notify_notifications
+    // 8. Table modifications for notify_notifications
     await queryRunner.addColumn(
       'notify_notifications',
       new TableColumn({
@@ -280,7 +280,7 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
       }),
     );
 
-    // 8. Table modifications for notify_archived_notifications
+    // 9. Table modifications for notify_archived_notifications
     await queryRunner.addColumn(
       'notify_archived_notifications',
       new TableColumn({

--- a/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
+++ b/apps/api/src/database/migrations/1751022743600-FallbackProviderChanges.ts
@@ -311,49 +311,44 @@ export class FallbackProviderChanges1751022743600 implements MigrationInterface 
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    {
-      // 1. Revert changes from table notify_archived_notifications
-      await queryRunner.dropIndex(
-        'notify_archived_notifications',
-        'IDX_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
-      );
-      await queryRunner.dropForeignKey(
-        'notify_archived_notifications',
-        'FK_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
-      );
-      await queryRunner.dropColumn('notify_archived_notifications', 'provider_chain_id');
+    // 1. Revert changes from table notify_archived_notifications
+    await queryRunner.dropIndex(
+      'notify_archived_notifications',
+      'IDX_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+    );
+    await queryRunner.dropForeignKey(
+      'notify_archived_notifications',
+      'FK_ARCHIVED_NOTIFICATIONS_PROVIDER_CHAIN',
+    );
+    await queryRunner.dropColumn('notify_archived_notifications', 'provider_chain_id');
 
-      // 2. Revert changes from table notify_notifications
-      await queryRunner.dropIndex('notify_notifications', 'IDX_NOTIFICATIONS_PROVIDER_CHAIN');
-      await queryRunner.dropForeignKey('notify_notifications', 'FK_NOTIFICATIONS_PROVIDER_CHAIN');
-      await queryRunner.dropColumn('notify_notifications', 'provider_chain_id');
+    // 2. Revert changes from table notify_notifications
+    await queryRunner.dropIndex('notify_notifications', 'IDX_NOTIFICATIONS_PROVIDER_CHAIN');
+    await queryRunner.dropForeignKey('notify_notifications', 'FK_NOTIFICATIONS_PROVIDER_CHAIN');
+    await queryRunner.dropColumn('notify_notifications', 'provider_chain_id');
 
-      // 3. Drop Unique Constraints
-      await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PROVIDER');
-      await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PRIORITY');
-      await queryRunner.dropUniqueConstraint('notify_provider_chains', 'UQ_APP_CHAIN_NAME');
+    // 3. Drop Unique Constraints
+    await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PROVIDER');
+    await queryRunner.dropUniqueConstraint('notify_provider_chain_members', 'UQ_CHAIN_PRIORITY');
+    await queryRunner.dropUniqueConstraint('notify_provider_chains', 'UQ_APP_CHAIN_NAME');
 
-      // 4. Drop Indexes
-      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_STATUS');
-      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_PROVIDER');
-      await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_CHAIN_ORDER');
+    // 4. Drop Indexes
+    await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_STATUS');
+    await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_PROVIDER');
+    await queryRunner.dropIndex('notify_provider_chain_members', 'IDX_CHAIN_MEMBERS_CHAIN_ORDER');
 
-      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_DEFAULT');
-      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_STATUS');
-      await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_APPLICATION_CHANNEL');
+    await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_DEFAULT');
+    await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_STATUS');
+    await queryRunner.dropIndex('notify_provider_chains', 'IDX_CHAINS_APPLICATION_CHANNEL');
 
-      // 5. Drop Foreign Key Constraints
-      await queryRunner.dropForeignKey(
-        'notify_provider_chain_members',
-        'FK_CHAIN_MEMBERS_PROVIDER',
-      );
-      await queryRunner.dropForeignKey('notify_provider_chain_members', 'FK_CHAIN_MEMBERS_CHAIN');
-      await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_CHANNEL_TYPE');
-      await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_APPLICATION');
+    // 5. Drop Foreign Key Constraints
+    await queryRunner.dropForeignKey('notify_provider_chain_members', 'FK_CHAIN_MEMBERS_PROVIDER');
+    await queryRunner.dropForeignKey('notify_provider_chain_members', 'FK_CHAIN_MEMBERS_CHAIN');
+    await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_CHANNEL_TYPE');
+    await queryRunner.dropForeignKey('notify_provider_chains', 'FK_PROVIDER_CHAINS_APPLICATION');
 
-      // 6. Drop tables in reverse order of creation to respect dependencies
-      await queryRunner.dropTable('notify_provider_chain_members');
-      await queryRunner.dropTable('notify_provider_chains');
-    }
+    // 6. Drop tables in reverse order of creation to respect dependencies
+    await queryRunner.dropTable('notify_provider_chain_members');
+    await queryRunner.dropTable('notify_provider_chains');
   }
 }

--- a/apps/api/src/modules/applications/entities/application.entity.ts
+++ b/apps/api/src/modules/applications/entities/application.entity.ts
@@ -13,6 +13,7 @@ import { Notification } from 'src/modules/notifications/entities/notification.en
 import { ServerApiKey } from 'src/modules/server-api-keys/entities/server-api-key.entity';
 import { ArchivedNotification } from 'src/modules/archived-notifications/entities/archived-notification.entity';
 import { GraphQLJSONObject } from 'graphql-type-json';
+import { ProviderChain } from 'src/modules/provider-chains/entities/provider-chain.entity';
 
 @Entity({ name: 'notify_applications' })
 @ObjectType()
@@ -75,6 +76,10 @@ export class Application {
     (archivedNotification) => archivedNotification.applicationDetails,
   )
   archivedNotifications: ArchivedNotification[];
+
+  @OneToMany(() => ProviderChain, (providerChain) => providerChain.applicationDetails)
+  @Field(() => [ProviderChain], { nullable: true })
+  providerChains: ProviderChain[];
 
   constructor(application: Partial<Application>) {
     Object.assign(this, application);

--- a/apps/api/src/modules/archived-notifications/entities/archived-notification.entity.ts
+++ b/apps/api/src/modules/archived-notifications/entities/archived-notification.entity.ts
@@ -14,6 +14,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { GraphQLJSONObject } from 'graphql-type-json';
 import { Application } from 'src/modules/applications/entities/application.entity';
 import { Provider } from 'src/modules/providers/entities/provider.entity';
+import { ProviderChain } from 'src/modules/provider-chains/entities/provider-chain.entity';
 
 @Entity({ name: 'notify_archived_notifications' })
 @ObjectType()
@@ -94,6 +95,11 @@ export class ArchivedNotification {
   @IsOptional()
   notificationSentOn: Date;
 
+  @Column({ name: 'provider_chain_id', nullable: true })
+  @Field({ nullable: true })
+  @IsOptional()
+  providerChainId: number;
+
   @ManyToOne(() => Application, (application) => application.archivedNotifications)
   @JoinColumn({ name: 'application_id' })
   @Field(() => Application)
@@ -103,4 +109,12 @@ export class ArchivedNotification {
   @JoinColumn({ name: 'provider_id' })
   @Field(() => Provider)
   providerDetails: Provider;
+
+  @ManyToOne(() => ProviderChain, (providerChain) => providerChain.archivedNotifications)
+  @JoinColumn({
+    name: 'provider_chain_id', // DB column name on THIS entity
+    referencedColumnName: 'chainId', // PROPERTY name on the REFERENCED entity (ProviderChain)
+  })
+  @Field(() => ProviderChain, { nullable: true })
+  providerChainDetails: ProviderChain;
 }

--- a/apps/api/src/modules/notifications/entities/notification.entity.ts
+++ b/apps/api/src/modules/notifications/entities/notification.entity.ts
@@ -16,6 +16,7 @@ import { GraphQLJSONObject } from 'graphql-type-json';
 import { Application } from 'src/modules/applications/entities/application.entity';
 import { Provider } from 'src/modules/providers/entities/provider.entity';
 import { RetryNotification } from './retry-notification.entity';
+import { ProviderChain } from 'src/modules/provider-chains/entities/provider-chain.entity';
 
 @Entity({ name: 'notify_notifications' })
 @ObjectType()
@@ -92,6 +93,11 @@ export class Notification {
   @IsOptional()
   notificationSentOn: Date;
 
+  @Column({ name: 'provider_chain_id', nullable: true })
+  @Field({ nullable: true })
+  @IsOptional()
+  providerChainId: number;
+
   @ManyToOne(() => Application, (application) => application.notifications)
   @JoinColumn({ name: 'application_id' })
   @Field(() => Application)
@@ -101,6 +107,14 @@ export class Notification {
   @JoinColumn({ name: 'provider_id' })
   @Field(() => Provider)
   providerDetails: Provider;
+
+  @ManyToOne(() => ProviderChain, (providerChain) => providerChain.notifications)
+  @JoinColumn({
+    name: 'provider_chain_id', // DB column name on THIS entity
+    referencedColumnName: 'chainId', // PROPERTY name on the REFERENCED entity (ProviderChain)
+  })
+  @Field(() => ProviderChain, { nullable: true })
+  providerChainDetails: ProviderChain;
 
   // TODO: Remove the retries relation in Notification and RetryNotification as the foreign key has been removed
   // Ensure archivedNotification and Notification entities have same parameters save for extra id

--- a/apps/api/src/modules/notifications/notifications.module.ts
+++ b/apps/api/src/modules/notifications/notifications.module.ts
@@ -47,6 +47,8 @@ import { JwtService } from '@nestjs/jwt';
 import { ArchivedNotificationsModule } from '../archived-notifications/archived-notifications.module';
 import { ArchivedNotificationsService } from '../archived-notifications/archived-notifications.service';
 import { RequestLoggerMiddleware } from 'src/common/logger/request-logger.middleware';
+import { ProviderChainsModule } from '../provider-chains/provider-chains.module';
+import { ProviderChainMembersModule } from '../provider-chain-members/provider-chain-members.module';
 
 const providerModules = [
   MailgunModule,
@@ -88,6 +90,8 @@ const consumers = [
     ...providerModules,
     WebhookModule,
     ArchivedNotificationsModule,
+    ProviderChainsModule,
+    ProviderChainMembersModule,
   ],
   providers: [
     NotificationsService,

--- a/apps/api/src/modules/provider-chain-members/entities/provider-chain-member.entity.ts
+++ b/apps/api/src/modules/provider-chain-members/entities/provider-chain-member.entity.ts
@@ -1,0 +1,75 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { IsEnum } from 'class-validator';
+import { Status } from 'src/common/constants/database';
+import { Field, ObjectType } from '@nestjs/graphql';
+import { ProviderChain } from 'src/modules/provider-chains/entities/provider-chain.entity';
+import { Provider } from 'src/modules/providers/entities/provider.entity';
+
+@Entity({ name: 'notify_provider_chain_members' })
+@ObjectType()
+export class ProviderChainMember {
+  @PrimaryGeneratedColumn({ name: 'id' })
+  @Field()
+  id: number;
+
+  @Column({ name: 'chain_id' })
+  @Field()
+  chainId: number;
+
+  @Column({ name: 'provider_id' })
+  @Field()
+  providerId: number;
+
+  @Column({ name: 'priority_order', type: 'smallint' })
+  @Field()
+  priorityOrder: number;
+
+  @Column({
+    name: 'is_active',
+    type: 'smallint',
+    default: Status.ACTIVE,
+  })
+  @IsEnum(Status)
+  @Field()
+  isActive: number;
+
+  @CreateDateColumn({ name: 'created_on' })
+  @Field()
+  createdOn: Date;
+
+  @UpdateDateColumn({ name: 'updated_on' })
+  @Field()
+  updatedOn: Date;
+
+  @Column({
+    name: 'status',
+    type: 'smallint',
+    width: 1,
+    default: Status.ACTIVE,
+  })
+  @IsEnum(Status)
+  @Field()
+  status: number;
+
+  @ManyToOne(() => ProviderChain, (providerChain) => providerChain.providerChainMembers)
+  @JoinColumn({ name: 'chain_id' })
+  @Field(() => ProviderChain)
+  providerChainDetails: ProviderChain;
+
+  @ManyToOne(() => Provider, (provider) => provider.notifications)
+  @JoinColumn({ name: 'provider_id' })
+  @Field(() => Provider)
+  providerDetails: Provider;
+
+  constructor(providerChain: Partial<ProviderChainMember>) {
+    Object.assign(this, providerChain);
+  }
+}

--- a/apps/api/src/modules/provider-chain-members/entities/provider-chain-member.entity.ts
+++ b/apps/api/src/modules/provider-chain-members/entities/provider-chain-member.entity.ts
@@ -64,7 +64,7 @@ export class ProviderChainMember {
   @Field(() => ProviderChain)
   providerChainDetails: ProviderChain;
 
-  @ManyToOne(() => Provider, (provider) => provider.notifications)
+  @ManyToOne(() => Provider, (provider) => provider.providerChainMembers)
   @JoinColumn({ name: 'provider_id' })
   @Field(() => Provider)
   providerDetails: Provider;

--- a/apps/api/src/modules/provider-chain-members/provider-chain-members.module.ts
+++ b/apps/api/src/modules/provider-chain-members/provider-chain-members.module.ts
@@ -1,0 +1,10 @@
+import { Logger, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProviderChainMember } from './entities/provider-chain-member.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ProviderChainMember])],
+  providers: [Logger],
+  exports: [TypeOrmModule],
+})
+export class ProviderChainMembersModule {}

--- a/apps/api/src/modules/provider-chains/entities/provider-chain.entity.ts
+++ b/apps/api/src/modules/provider-chains/entities/provider-chain.entity.ts
@@ -1,0 +1,102 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  CreateDateColumn,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
+import { IsEnum, IsOptional } from 'class-validator';
+import { IsDefaultStatus, Status } from 'src/common/constants/database';
+import { Field, ObjectType } from '@nestjs/graphql';
+import { ChannelType } from 'src/common/constants/notifications';
+import { Application } from 'src/modules/applications/entities/application.entity';
+import { ProviderChainMember } from 'src/modules/provider-chain-members/entities/provider-chain-member.entity';
+import { Notification } from 'src/modules/notifications/entities/notification.entity';
+import { ArchivedNotification } from 'src/modules/archived-notifications/entities/archived-notification.entity';
+
+@Entity({ name: 'notify_provider_chains' })
+@ObjectType()
+export class ProviderChain {
+  @PrimaryGeneratedColumn({ name: 'chain_id' })
+  @Field()
+  chainId: number;
+
+  @Column({ name: 'chain_name' })
+  @Field()
+  chainName: string;
+
+  @Column({ name: 'application_id' })
+  @Field()
+  applicationId: number;
+
+  @Column({ name: 'channel_type', type: 'smallint' })
+  @IsEnum(ChannelType)
+  @Field()
+  channelType: number;
+
+  @Column({
+    name: 'description',
+    type: 'text',
+    nullable: true,
+  })
+  @IsOptional()
+  @Field()
+  description: string;
+
+  @Column({
+    name: 'is_default',
+    type: 'smallint',
+    width: 1,
+    default: IsDefaultStatus.FALSE,
+  })
+  @IsEnum(IsDefaultStatus)
+  @Field()
+  isDefault: number;
+
+  @CreateDateColumn({ name: 'created_on' })
+  @Field()
+  createdOn: Date;
+
+  @UpdateDateColumn({ name: 'updated_on' })
+  @Field()
+  updatedOn: Date;
+
+  @Column({
+    name: 'status',
+    type: 'smallint',
+    width: 1,
+    default: Status.ACTIVE,
+  })
+  @IsEnum(Status)
+  @Field()
+  status: number;
+
+  @ManyToOne(() => Application, (application) => application.providerChains)
+  @JoinColumn({ name: 'application_id' })
+  @Field(() => Application)
+  applicationDetails: Application;
+
+  @OneToMany(
+    () => ProviderChainMember,
+    (providerChainMember) => providerChainMember.providerChainDetails,
+  )
+  providerChainMembers: ProviderChainMember[];
+
+  @OneToMany(() => Notification, (notification) => notification.providerChainDetails)
+  @Field(() => [Notification], { nullable: true })
+  notifications: Notification[];
+
+  @OneToMany(
+    () => ArchivedNotification,
+    (archivedNotification) => archivedNotification.providerChainDetails,
+  )
+  @Field(() => [ArchivedNotification], { nullable: true })
+  archivedNotifications: ArchivedNotification[];
+
+  constructor(providerChain: Partial<ProviderChain>) {
+    Object.assign(this, providerChain);
+  }
+}

--- a/apps/api/src/modules/provider-chains/provider-chains.module.ts
+++ b/apps/api/src/modules/provider-chains/provider-chains.module.ts
@@ -1,0 +1,10 @@
+import { Logger, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProviderChain } from './entities/provider-chain.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ProviderChain])],
+  providers: [Logger],
+  exports: [TypeOrmModule],
+})
+export class ProviderChainsModule {}

--- a/apps/api/src/modules/providers/entities/provider.entity.ts
+++ b/apps/api/src/modules/providers/entities/provider.entity.ts
@@ -13,6 +13,7 @@ import {
 } from 'typeorm';
 import { Notification } from 'src/modules/notifications/entities/notification.entity';
 import { ArchivedNotification } from 'src/modules/archived-notifications/entities/archived-notification.entity';
+import { ProviderChainMember } from 'src/modules/provider-chain-members/entities/provider-chain-member.entity';
 
 @Entity({ name: 'notify_providers' })
 @ObjectType()
@@ -79,6 +80,13 @@ export class Provider {
     (archivedNotification) => archivedNotification.providerDetails,
   )
   archivedNotifications: ArchivedNotification[];
+
+  @OneToMany(
+    () => ProviderChainMember,
+    (ProviderChainMember) => ProviderChainMember.providerDetails,
+  )
+  @Field(() => [ProviderChainMember], { nullable: true })
+  providerChainMembers: ProviderChainMember[];
 
   constructor(provider: Partial<Provider>) {
     Object.assign(this, provider);


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-338](https://pinestem.com/dashboard.html#/tasks/OSXT-338/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

Configure entities for fallback provider chains

**Related changes:**

- Add module and entity for provider chains
- Add module and entity for provider chain members
- Update notification and archived notification entities - add new field provider_chain_id and make it nullable
- Add foreign key constraints using TypeORM relation decorators
- Do regression testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for provider chains, including new entities for provider chains and their members.
  * Added new database tables and relationships for managing provider chains and their members.
  * Extended notifications and archived notifications to optionally reference a provider chain.
  * Updated the application and provider entities to expose related provider chains and chain members in the API.

* **Chores**
  * Added new modules to manage provider chains and their members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->