### PR TITLE
feat: add table notify_provider_types

### DIFF
--- a/apps/api/src/common/constants/database.ts
+++ b/apps/api/src/common/constants/database.ts
@@ -12,9 +12,10 @@ export const ProviderType = {
   OTHER: 0,
   EMAIL: 1,
   SMS: 2,
-  WHATSAPP: 3,
+  WHATSAPP_BUSINESS_TEMPLATE: 3,
   PUSH_NOTIFICATION: 4,
   VOICE_CALL: 5,
+  WHATSAPP_DIRECT: 6,
 };
 
 export const IsEnabledStatus = {

--- a/apps/api/src/database/migrations/1752740502422-AddTableProviderType.ts
+++ b/apps/api/src/database/migrations/1752740502422-AddTableProviderType.ts
@@ -1,0 +1,135 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableUnique } from 'typeorm';
+
+export class AddTableProviderTypes1752740502422 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Create notify_provider_types table
+    await queryRunner.createTable(
+      new Table({
+        name: 'notify_provider_types',
+        columns: [
+          {
+            name: 'provider_type_id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+            isUnique: true,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'created_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_on',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'smallint',
+            isNullable: false,
+            default: 1,
+          },
+        ],
+      }),
+      true,
+    );
+
+    // 2. Add Unique Constraints
+    await queryRunner.createUniqueConstraint(
+      'notify_provider_types',
+      new TableUnique({
+        columnNames: ['provider_type_id', 'name'],
+        name: 'UQ_PROVIDER_TYPE_NAME',
+      }),
+    );
+
+    // 3. Seed Data
+    const providerTypesData = [
+      {
+        name: 'Email',
+        description: 'Provider type: Email',
+      },
+      {
+        name: 'SMS',
+        description: 'Provider type: SMS',
+      },
+      {
+        name: 'WhatsApp Business Template',
+        description: 'Provider type: WhatsApp Business Template',
+      },
+      {
+        name: 'Push Notification',
+        description: 'Provider type: Push Notification',
+      },
+      {
+        name: 'Voice Call',
+        description: 'Provider type: Voice Call',
+      },
+      {
+        name: 'WhatsApp Direct',
+        description: 'Provider type: WhatsApp Direct',
+      },
+    ];
+
+    for (const typeData of providerTypesData) {
+      await queryRunner.manager
+        .createQueryBuilder()
+        .insert()
+        .into('notify_provider_types')
+        .values(typeData)
+        .execute();
+    }
+
+    // 4. Update provider_type for WA_TWILIO in notify_master_providers
+    await queryRunner.query(`
+      UPDATE notify_master_providers
+      SET provider_type = 6
+      WHERE name = 'WA_TWILIO';
+    `);
+
+    // 5. Add Foreign Key Constraints for notify_master_providers
+    await queryRunner.createForeignKey(
+      'notify_master_providers',
+      new TableForeignKey({
+        columnNames: ['provider_type'],
+        referencedColumnNames: ['provider_type_id'],
+        referencedTableName: 'notify_provider_types',
+        onDelete: 'SET NULL',
+        name: 'FK_MASTER_PROVIDERS_PROVIDER_TYPE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 1. Revert changes from notify_master_providers
+    await queryRunner.dropForeignKey(
+      'notify_master_providers',
+      'FK_MASTER_PROVIDERS_PROVIDER_TYPE',
+    );
+
+    await queryRunner.query(`
+      UPDATE notify_master_providers
+      SET provider_type = 3
+      WHERE name = 'WA_TWILIO';
+    `);
+
+    // 2. Drop table notify_provider_types
+    await queryRunner.dropUniqueConstraint('notify_provider_types', 'UQ_PROVIDER_TYPE_NAME');
+    await queryRunner.dropTable('notify_provider_types');
+  }
+}

--- a/apps/api/src/database/migrations/1752740502422-AddTableProviderType.ts
+++ b/apps/api/src/database/migrations/1752740502422-AddTableProviderType.ts
@@ -112,10 +112,14 @@ export class AddTableProviderTypes1752740502422 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     // 1. Revert changes from notify_master_providers
-    await queryRunner.dropForeignKey(
-      'notify_master_providers',
-      'FK_MASTER_PROVIDERS_PROVIDER_TYPE',
+    const table = await queryRunner.getTable('notify_master_providers');
+    const foreignKey = table?.foreignKeys.find(
+      (fk) => fk.name === 'FK_MASTER_PROVIDERS_PROVIDER_TYPE',
     );
+
+    if (foreignKey) {
+      await queryRunner.dropForeignKey('notify_master_providers', foreignKey);
+    }
 
     await queryRunner.query(`
       UPDATE notify_master_providers


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-346](https://pinestem.com/dashboard.html#/tasks/OSXT-346/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [x] Related changes have been added (optional)
- [x] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

Add table notify_provider_types

**Related changes:**

- Add table notify_provider_types
- Add unique constraint on name
- Seed data for table notify_provider_types
- Update provider_type for WA_TWILIO in notify_master_providers
- Add foreign key constraints notify_master_providers

**Screenshots:**

provider types
<img width="1253" height="288" alt="image" src="https://github.com/user-attachments/assets/dc985fde-aa84-4251-b092-0b010cd686da" />

master providers
<img width="1321" height="495" alt="image" src="https://github.com/user-attachments/assets/0619c177-2e89-4f20-816a-aa66f404ace3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new notification provider types, including WhatsApp Business Template and WhatsApp Direct, enhancing channel options.

* **Chores**
  * Updated existing provider configurations to integrate with the expanded provider types system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->