### PR TITLE
fix: add null check for provider getById service method

### DIFF
--- a/apps/api/src/jobs/producers/notifications/notifications.job.producer.ts
+++ b/apps/api/src/jobs/producers/notifications/notifications.job.producer.ts
@@ -15,6 +15,11 @@ export class NotificationQueueProducer {
   async addNotificationToQueue(queueType: string, notification: Notification): Promise<void> {
     this.logger.debug('Started addNotificationToQueue');
     const provider = await this.providersService.getById(notification.providerId);
+
+    if (!provider) {
+      throw new Error(`Provider with ID ${notification.providerId} not found.`);
+    }
+
     this.logger.debug(
       `Fetched provider ${JSON.stringify(provider)} from notification ${JSON.stringify(notification)}`,
     );

--- a/apps/api/src/modules/providers/providers.service.ts
+++ b/apps/api/src/modules/providers/providers.service.ts
@@ -23,7 +23,11 @@ export class ProvidersService extends CoreService<Provider> {
     super(providerRepository);
   }
 
-  async getById(providerId: number): Promise<Provider | undefined> {
+  async getById(providerId: number): Promise<Provider | null> {
+    if (providerId === undefined || providerId === null) {
+      return null;
+    }
+
     return this.providerRepository.findOne({ where: { providerId, status: Status.ACTIVE } });
   }
 


### PR DESCRIPTION
## API PR Checklist

### Task Link

Osmosys Developers must include the Pinestem task link in the PR.

[OSXT-363](https://pinestem.com/dashboard.html#/tasks/quick/OSXT-363/details/?companyId=453&isPrevNext=1)

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](https://github.com/OsmosysSoftware/osmo-x/blob/main/CONTRIBUTING.md#-submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed unit testing for the new feature added or updated to ensure the new features added are working as expected.
- [ ] I have added/updated test cases to the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) as applicable.
- [ ] I have performed preliminary testing using the [test suite](https://github.com/OsmosysSoftware/osmo-x/blob/main/apps/api/OsmoX.postman_collection.json) to ensure that any existing features are not impacted and any new features are working as expected as a whole.
- [ ] I have added/updated the required [api docs](https://github.com/OsmosysSoftware/osmo-x/tree/main/apps/api/docs) as applicable.
- [ ] I have added/updated the `.env.example` file with the required values as applicable.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login endpoint`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Query request and response examples have been added (as applicable, in case added or updated)
- [ ] Documentation changes have been listed (as applicable)
- [ ] Test suite/unit testing output is added (as applicable)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [x] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [x] Assignee(s) and reviewer(s) have been added (optional)

_Note: Reviewer should ensure that the checklist and description have been populated and followed correctly, and the PR should be merged only after resolving all conversations and verifying that CI checks pass._

---

**Description:**

- Return null when null or undefined values are passed to get provider by id
- Add null checks for fetched providers
- Add a null check when fetching providers for method `addNotificationToQueue` in `notification.job.producer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when sending notifications by failing fast if the selected provider is unavailable, preventing downstream errors and crashes.
  - Standardized handling of missing or invalid provider IDs to ensure consistent behavior across the app.
  - Added clearer error messaging when a provider cannot be found, making issues easier to diagnose.
  - Overall stabilization of notification processing to reduce ambiguous states and improve predictability for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->